### PR TITLE
Fix markdown linting issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,33 +2,33 @@
 
 ----
 
-Thanks for your interest in contributing to this package! We're hoping it can be made even better through community contributions. 
-	
-# Requests and feedback 
+Thanks for your interest in contributing to this package! We're hoping it can be made even better through community contributions.
+
+## Requests and feedback
 
 For any bugs, issues or feature requests please open an [issue](https://github.com/lvgig/tubular/issues) on the project.
 
-# Requirements for contributions 
+## Requirements for contributions
 
 We have some general requirements for all contributions then specific requirements when adding completely new transformers to the package. This is to ensure consistency with the existing codebase.
 
-## Code formatting
+### Code formatting
 
 Contributions should be formatted with `black`. There is a `pre-commit` file in the `.githooks` folder that can be activated for your local clone of the repo with `git config core.hooksPath .githooks`.
 
-## Tests
+### Tests
 
-All existing tests must pass and new functionality added must be tested. Tests must be written with [pytest](https://docs.pytest.org/en/stable/). The tests for existing transformers give great examples to work from that show what is expected to be covered in the tests. 
+All existing tests must pass and new functionality added must be tested. Tests must be written with [pytest](https://docs.pytest.org/en/stable/). The tests for existing transformers give great examples to work from that show what is expected to be covered in the tests.
 
-## Docstrings
+### Docstrings
 
 Docstrings need to be updated or added for new functionality.
 
-## New transformers
+### New transformers
 
 To be consistent with `scikit-learn` - all transformers will implement at least an `__init__` and `transform(X)` method, then a `fit(X, y=None)` method if there is something to learn from the training data and potentially an `reverse_transform(X)` method too. We can group the common functionality of transformers we expect to be tested together by method;
 
-# List of contributors
+## List of contributors
 
 Prior to the open source release of the package there have been contributions from many individuals in the LV GI Data Science team;
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,53 +2,53 @@
 
 ----
 
-# 0.2.14
+## 0.2.14
 
 - Open source release of code on Github
 
-# 0.2.13
+## 0.2.13
 
 - Added base parameter to LogTransformer in numeric module
 - Fixed bug in MappingTransformer in mapping module. Changed local variable to be instantiated as deepcopy of input parameter.
 
-# 0.2.12
+## 0.2.12
 
 - Add OrdinalEncoderTransformer in noninal module
 - Add check that X has rows in BaseTransformer transform method
 - Use kind="stable" in numpy argsort and kind="mergesort" in pandas sort_values for stable sorting
 - Fix OutOfRangeNullTransformer not returning self from fit
 
-# 0.2.11
+## 0.2.11
 
 - Change ArbitraryImputer so that columns must be set in init
 - Swap out assert_function_call_b and assert_function_call_count_b functions for new assert_function_call and assert_function_call_count context manager versions
 - Add support for pd.Index objects in testing.helpers.assert_equal_dispatch
 
-# 0.2.10
+## 0.2.10
 
 - Change assert_function_call and assert_function_call_count to be context managers
 - Rename existing assert_function_call and assert_function_call_count functions to assert_function_call_b and assert_function_call_count_b
 - Simplify assert_eqaul_dispatch function
 
-# 0.2.9
+## 0.2.9
 
-- Add BaseImputer class and make other imputer classes inherit from BaseImputer 
+- Add BaseImputer class and make other imputer classes inherit from BaseImputer
 - Change NominalColumnSetOrCheckMixin to be BaseNominalTransformer 
-- Rename replacements_ attribute to mappings in MeanResponseTransformer to be consistent with MappingTransformer 
-- Rename replacements_ attribute to mappings in NominalToIntegerTransformer to be consistent with MappingTransformer 
-- Uupdate BaseTransformer.transform to call columns_check instead of columns_set_or_check 
-- Added method to BaseNominalTransformer to checks for mappable rows and raises an error if non-mappable rows are found 
-- Implement BaseMappingTransformMixin class and inherit from that in MappingTransformer 
+- Rename replacements_ attribute to mappings in MeanResponseTransformer to be consistent with MappingTransformer
+- Rename replacements_ attribute to mappings in NominalToIntegerTransformer to be consistent with MappingTransformer
+- Uupdate BaseTransformer.transform to call columns_check instead of columns_set_or_check
+- Added method to BaseNominalTransformer to checks for mappable rows and raises an error if non-mappable rows are found
+- Implement BaseMappingTransformMixin class and inherit from that in MappingTransformer
 - Update MeanResponseTransformer and NominalToIntegerTransformer to take their transform method from BaseMappingTransformMixin
-- Update GroupRareLevelsTransformer to map columns using pd.where() insteand of np.where() 
+- Update GroupRareLevelsTransformer to map columns using pd.where() insteand of np.where()
 
-# 0.2.8
+## 0.2.8
 
 - Rename package from prepro to tubular
 
-# 0.2.7
+## 0.2.7
 
-- Add fit method to calculate weighted quantiles to CappingTransformer 
+- Add fit method to calculate weighted quantiles to CappingTransformer
 - Add CutTransformer
 - Add LogTransformer
 - Add ToDatetimeTransformer
@@ -59,14 +59,14 @@
 - Add SetVaueTransformer
 - Add BetweenDatesTransformer
 
-# 0.2.6
+## 0.2.6
 
 - Update build pipelines
 - Add date diff transformer (Y, M, D, h, m, s units)
 - Rename DateDiffYearTransformer to DateDiffLeapYearTransformer
 - Add DataFrameMethodTransformer
 
-# 0.2.5
+## 0.2.5
 
 - Add files in preparation for open source release
 - Restructure test helper files
@@ -74,88 +74,88 @@
 - Remove exception raised decorator
 - Add row_by_row_params and index_preserved_params test helpers and update tests to use
 
-# 0.2.4
+## 0.2.4
 
-- Change imports for test helpers 
+- Change imports for test helpers
 
-# 0.2.3
+## 0.2.3
 
 - Add mean imputer
 - Add mode imputer
 
-# 0.2.2
+## 0.2.2
 
 - Add date diff year transformer
 
-# 0.2.1
+## 0.2.1
 
 - Add nearest mean response imputer
 - Add null indicator
 
-# 0.2.0 
+## 0.2.0
 
-- Refactor test suite 
+- Refactor test suite
 - Improve documentation
 - Add cross column mapping transformers
 
-# 0.1.13
+## 0.1.13
 
 - Fix to one hot encoder to preserve index
 
-# 0.1.12
+## 0.1.12
 
 - Add capping transformer
 
-# 0.1.11
+## 0.1.11
 
 - Add y arg to one hot encoder
 
-# 0.1.10
+## 0.1.10
 
 - Add one hot encoder
 
-# 0.1.9
+## 0.1.9
 
 - Fix for pandas update
 
-# 0.1.8
+## 0.1.8
 
 - Improve speed of mapping transformer
 
-# 0.1.7
+## 0.1.7
 
 - Fix missing y arg in mean response transformer
 
-# 0.1.6
+## 0.1.6
 
 - Add mapping transformer
 
-# 0.1.5
+## 0.1.5
 
 - Add mean response transformer
 
-# 0.1.4
+## 0.1.4
 
 - Improve speed of rare level grouper
 - Improve speed of imputers
 
-# 0.1.3
+## 0.1.3
 
 - Add checks on inputs for base transformer
 - Add requirements.txt
 
-# 0.1.2
+## 0.1.2
 
 - Fix for rare level grouper
 
-# 0.1.1
+## 0.1.1
 
 - Add version attribute
 
-# 0.1.0
+## 0.1.0
 
 - Add base transformer
 - Add nominal to integer transformer
-- Add categorical rare level grouper 
+- Add categorical rare level grouper
 - Add arbitrary imputer
 - Add median imputer

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# tubular 
+# tubular
 
 ----
 
-`tubular` implements transformers for pre processing steps commonly used in machine learning pipelines. 
+`tubular` implements transformers for pre processing steps commonly used in machine learning pipelines.
 
-The transformers are compatible with scikit-learn [Pipelines](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html), having a `transform` method to apply the pre processing step to data and a `fit` method to learn the relevant information from the data, if applicable. 
+The transformers are compatible with scikit-learn [Pipelines](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html), having a `transform` method to apply the pre processing step to data and a `fit` method to learn the relevant information from the data, if applicable.
 
-The transformers in `tubular` work with data in [pandas DataFrames](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html). 
+The transformers in `tubular` work with data in [pandas DataFrames](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
 There are a variety of transformers to assist with;
 
 - capping
 - imputation
 - mapping
-- date differencing 
+- date differencing
 - categorical encoding
 - numeric operations
 
@@ -36,21 +36,21 @@ capper = CappingTransformer(columns=['INDUS', 'RM'], cap_value_max = 20)
 X_capped = capper.transform(X)
 ```
 
-# Installation
+## Installation
 
 tubular can be installed from PyPI simply with;
 
  `pip install tubular`
 
-# Documentation
+## Documentation
 
 Documentation for tubular can be found on [readthedocs](https://tubular.readthedocs.io/en/latest/).
 
-# Examples
+## Examples
 
 To help get started there are example notebooks in the [examples](https://github.com/lvgig/tubular/tree/master/examples) folder that show how to use each transformer as well as an example of putting several together in a Pipeline.
 
-# Build and test
+## Build and test
 
 The test framework we are using for this project is [pytest](https://docs.pytest.org/en/stable/), to run the tests follow the steps below.
 
@@ -73,9 +73,8 @@ Then run the tests simply with pytest
 pytest
 ```
 
-# Contribute
+## Contribute
 
-`tubular` is under active development, we're super excited if you're interested in contributing! See the `CONTRIBUTING.md` for the full details of our working practices. 
+`tubular` is under active development, we're super excited if you're interested in contributing! See the `CONTRIBUTING.md` for the full details of our working practices.
 
 For bugs and feature requests please open an [issue](https://github.com/lvgig/tubular/issues).
-


### PR DESCRIPTION
Just some small things that showed up in my editor (VS Code) with markdown linting enabled.

* MD025/single-title/single-h1: Multiple top-level headings in the same document
* MD009/no-trailing-spaces: Trailing spaces