### PR TITLE
Sphinxify api

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,2 @@
+# For Sphinx build documentation
+export SPHINX_BUILD_DIR=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,33 +2,33 @@
 
 ----
 
-Thanks for your interest in contributing to this package! We're hoping it can be made even better through community contributions. 
-	
-# Requests and feedback 
+Thanks for your interest in contributing to this package! We're hoping it can be made even better through community contributions.
+
+## Requests and feedback
 
 For any bugs, issues or feature requests please open an [issue](https://github.com/lvgig/tubular/issues) on the project.
 
-# Requirements for contributions 
+## Requirements for contributions
 
 We have some general requirements for all contributions then specific requirements when adding completely new transformers to the package. This is to ensure consistency with the existing codebase.
 
-## Code formatting
+### Code formatting
 
 Contributions should be formatted with `black`. There is a `pre-commit` file in the `.githooks` folder that can be activated for your local clone of the repo with `git config core.hooksPath .githooks`.
 
-## Tests
+### Tests
 
-All existing tests must pass and new functionality added must be tested. Tests must be written with [pytest](https://docs.pytest.org/en/stable/). The tests for existing transformers give great examples to work from that show what is expected to be covered in the tests. 
+All existing tests must pass and new functionality added must be tested. Tests must be written with [pytest](https://docs.pytest.org/en/stable/). The tests for existing transformers give great examples to work from that show what is expected to be covered in the tests.
 
-## Docstrings
+### Docstrings
 
 Docstrings need to be updated or added for new functionality.
 
-## New transformers
+### New transformers
 
 To be consistent with `scikit-learn` - all transformers will implement at least an `__init__` and `transform(X)` method, then a `fit(X, y=None)` method if there is something to learn from the training data and potentially an `reverse_transform(X)` method too. We can group the common functionality of transformers we expect to be tested together by method;
 
-# List of contributors
+## List of contributors
 
 Prior to the open source release of the package there have been contributions from many individuals in the LV GI Data Science team;
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,53 +2,53 @@
 
 ----
 
-# 0.2.14
+## 0.2.14
 
 - Open source release of code on Github
 
-# 0.2.13
+## 0.2.13
 
 - Added base parameter to LogTransformer in numeric module
 - Fixed bug in MappingTransformer in mapping module. Changed local variable to be instantiated as deepcopy of input parameter.
 
-# 0.2.12
+## 0.2.12
 
 - Add OrdinalEncoderTransformer in noninal module
 - Add check that X has rows in BaseTransformer transform method
 - Use kind="stable" in numpy argsort and kind="mergesort" in pandas sort_values for stable sorting
 - Fix OutOfRangeNullTransformer not returning self from fit
 
-# 0.2.11
+## 0.2.11
 
 - Change ArbitraryImputer so that columns must be set in init
 - Swap out assert_function_call_b and assert_function_call_count_b functions for new assert_function_call and assert_function_call_count context manager versions
 - Add support for pd.Index objects in testing.helpers.assert_equal_dispatch
 
-# 0.2.10
+## 0.2.10
 
 - Change assert_function_call and assert_function_call_count to be context managers
 - Rename existing assert_function_call and assert_function_call_count functions to assert_function_call_b and assert_function_call_count_b
 - Simplify assert_eqaul_dispatch function
 
-# 0.2.9
+## 0.2.9
 
-- Add BaseImputer class and make other imputer classes inherit from BaseImputer 
+- Add BaseImputer class and make other imputer classes inherit from BaseImputer
 - Change NominalColumnSetOrCheckMixin to be BaseNominalTransformer 
-- Rename replacements_ attribute to mappings in MeanResponseTransformer to be consistent with MappingTransformer 
-- Rename replacements_ attribute to mappings in NominalToIntegerTransformer to be consistent with MappingTransformer 
-- Uupdate BaseTransformer.transform to call columns_check instead of columns_set_or_check 
-- Added method to BaseNominalTransformer to checks for mappable rows and raises an error if non-mappable rows are found 
-- Implement BaseMappingTransformMixin class and inherit from that in MappingTransformer 
+- Rename replacements_ attribute to mappings in MeanResponseTransformer to be consistent with MappingTransformer
+- Rename replacements_ attribute to mappings in NominalToIntegerTransformer to be consistent with MappingTransformer
+- Uupdate BaseTransformer.transform to call columns_check instead of columns_set_or_check
+- Added method to BaseNominalTransformer to checks for mappable rows and raises an error if non-mappable rows are found
+- Implement BaseMappingTransformMixin class and inherit from that in MappingTransformer
 - Update MeanResponseTransformer and NominalToIntegerTransformer to take their transform method from BaseMappingTransformMixin
-- Update GroupRareLevelsTransformer to map columns using pd.where() insteand of np.where() 
+- Update GroupRareLevelsTransformer to map columns using pd.where() insteand of np.where()
 
-# 0.2.8
+## 0.2.8
 
 - Rename package from prepro to tubular
 
-# 0.2.7
+## 0.2.7
 
-- Add fit method to calculate weighted quantiles to CappingTransformer 
+- Add fit method to calculate weighted quantiles to CappingTransformer
 - Add CutTransformer
 - Add LogTransformer
 - Add ToDatetimeTransformer
@@ -59,14 +59,14 @@
 - Add SetVaueTransformer
 - Add BetweenDatesTransformer
 
-# 0.2.6
+## 0.2.6
 
 - Update build pipelines
 - Add date diff transformer (Y, M, D, h, m, s units)
 - Rename DateDiffYearTransformer to DateDiffLeapYearTransformer
 - Add DataFrameMethodTransformer
 
-# 0.2.5
+## 0.2.5
 
 - Add files in preparation for open source release
 - Restructure test helper files
@@ -74,88 +74,88 @@
 - Remove exception raised decorator
 - Add row_by_row_params and index_preserved_params test helpers and update tests to use
 
-# 0.2.4
+## 0.2.4
 
-- Change imports for test helpers 
+- Change imports for test helpers
 
-# 0.2.3
+## 0.2.3
 
 - Add mean imputer
 - Add mode imputer
 
-# 0.2.2
+## 0.2.2
 
 - Add date diff year transformer
 
-# 0.2.1
+## 0.2.1
 
 - Add nearest mean response imputer
 - Add null indicator
 
-# 0.2.0 
+## 0.2.0
 
-- Refactor test suite 
+- Refactor test suite
 - Improve documentation
 - Add cross column mapping transformers
 
-# 0.1.13
+## 0.1.13
 
 - Fix to one hot encoder to preserve index
 
-# 0.1.12
+## 0.1.12
 
 - Add capping transformer
 
-# 0.1.11
+## 0.1.11
 
 - Add y arg to one hot encoder
 
-# 0.1.10
+## 0.1.10
 
 - Add one hot encoder
 
-# 0.1.9
+## 0.1.9
 
 - Fix for pandas update
 
-# 0.1.8
+## 0.1.8
 
 - Improve speed of mapping transformer
 
-# 0.1.7
+## 0.1.7
 
 - Fix missing y arg in mean response transformer
 
-# 0.1.6
+## 0.1.6
 
 - Add mapping transformer
 
-# 0.1.5
+## 0.1.5
 
 - Add mean response transformer
 
-# 0.1.4
+## 0.1.4
 
 - Improve speed of rare level grouper
 - Improve speed of imputers
 
-# 0.1.3
+## 0.1.3
 
 - Add checks on inputs for base transformer
 - Add requirements.txt
 
-# 0.1.2
+## 0.1.2
 
 - Fix for rare level grouper
 
-# 0.1.1
+## 0.1.1
 
 - Add version attribute
 
-# 0.1.0
+## 0.1.0
 
 - Add base transformer
 - Add nominal to integer transformer
-- Add categorical rare level grouper 
+- Add categorical rare level grouper
 - Add arbitrary imputer
 - Add median imputer

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# tubular 
+# tubular
 
 ----
 
-`tubular` implements transformers for pre processing steps commonly used in machine learning pipelines. 
+`tubular` implements transformers for pre processing steps commonly used in machine learning pipelines.
 
-The transformers are compatible with scikit-learn [Pipelines](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html), having a `transform` method to apply the pre processing step to data and a `fit` method to learn the relevant information from the data, if applicable. 
+The transformers are compatible with scikit-learn [Pipelines](https://scikit-learn.org/stable/modules/generated/sklearn.pipeline.Pipeline.html), having a `transform` method to apply the pre processing step to data and a `fit` method to learn the relevant information from the data, if applicable.
 
-The transformers in `tubular` work with data in [pandas DataFrames](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html). 
+The transformers in `tubular` work with data in [pandas DataFrames](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html).
 
 There are a variety of transformers to assist with;
 
 - capping
 - imputation
 - mapping
-- date differencing 
+- date differencing
 - categorical encoding
 - numeric operations
 
@@ -36,21 +36,21 @@ capper = CappingTransformer(columns=['INDUS', 'RM'], cap_value_max = 20)
 X_capped = capper.transform(X)
 ```
 
-# Installation
+## Installation
 
 tubular can be installed from PyPI simply with;
 
  `pip install tubular`
 
-# Documentation
+## Documentation
 
 Documentation for tubular can be found on [readthedocs](https://tubular.readthedocs.io/en/latest/).
 
-# Examples
+## Examples
 
 To help get started there are example notebooks in the [examples](https://github.com/lvgig/tubular/tree/master/examples) folder that show how to use each transformer as well as an example of putting several together in a Pipeline.
 
-# Build and test
+## Build and test
 
 The test framework we are using for this project is [pytest](https://docs.pytest.org/en/stable/), to run the tests follow the steps below.
 
@@ -73,9 +73,8 @@ Then run the tests simply with pytest
 pytest
 ```
 
-# Contribute
+## Contribute
 
-`tubular` is under active development, we're super excited if you're interested in contributing! See the `CONTRIBUTING.md` for the full details of our working practices. 
+`tubular` is under active development, we're super excited if you're interested in contributing! See the `CONTRIBUTING.md` for the full details of our working practices.
 
 For bugs and feature requests please open an [issue](https://github.com/lvgig/tubular/issues).
-

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To build local documentation, specify the environment variable $SPHINX_BUILD_DIR
 run from the `docs/` directory
 
 ```shell
-sphinx-apidoc -fMe ../tubular -o source/api
+make apidoc
 make html
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ tubular can be installed from PyPI simply with;
 
 ## Documentation
 
-Documentation for tubular can be found on [readthedocs](https://tubular.readthedocs.io/en/latest/).
+To build local documentation, specify the environment variable $SPHINX_BUILD_DIR$, and then
+run from the `docs/` directory
+
+```shell
+sphinx-apidoc -fMe ../tubular -o source/api
+make html
+```
 
 ## Examples
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = $(SPHINX_BUILD_DIR)
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,18 @@ help:
 
 .PHONY: help Makefile
 
+# Autodoc creation with apidoc
+apidoc:
+	sphinx-apidoc -fMe ../tubular -o source/api
+	@echo "Auto-generation of API documentation finished;" \
+		"removing unwanted output."
+	rm source/api/modules.rst
+	rm source/api/tubular.rst
+	rm source/api/tubular.testing*.rst
+
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,9 @@
+API Documentation
+=================
+
+Information on specific functions, classes, and methods.
+
+.. toctree::
+   :glob:
+
+   api/*

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,0 +1,7 @@
+tubular
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   tubular

--- a/docs/source/api/tubular.base.rst
+++ b/docs/source/api/tubular.base.rst
@@ -1,0 +1,7 @@
+tubular.base module
+===================
+
+.. automodule:: tubular.base
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.capping.rst
+++ b/docs/source/api/tubular.capping.rst
@@ -1,0 +1,7 @@
+tubular.capping module
+======================
+
+.. automodule:: tubular.capping
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.dates.rst
+++ b/docs/source/api/tubular.dates.rst
@@ -1,0 +1,7 @@
+tubular.dates module
+====================
+
+.. automodule:: tubular.dates
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.imputers.rst
+++ b/docs/source/api/tubular.imputers.rst
@@ -1,0 +1,7 @@
+tubular.imputers module
+=======================
+
+.. automodule:: tubular.imputers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.mapping.rst
+++ b/docs/source/api/tubular.mapping.rst
@@ -1,0 +1,7 @@
+tubular.mapping module
+======================
+
+.. automodule:: tubular.mapping
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.misc.rst
+++ b/docs/source/api/tubular.misc.rst
@@ -1,0 +1,7 @@
+tubular.misc module
+===================
+
+.. automodule:: tubular.misc
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.nominal.rst
+++ b/docs/source/api/tubular.nominal.rst
@@ -1,0 +1,7 @@
+tubular.nominal module
+======================
+
+.. automodule:: tubular.nominal
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.numeric.rst
+++ b/docs/source/api/tubular.numeric.rst
@@ -1,0 +1,7 @@
+tubular.numeric module
+======================
+
+.. automodule:: tubular.numeric
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.rst
+++ b/docs/source/api/tubular.rst
@@ -1,0 +1,31 @@
+tubular package
+===============
+
+.. automodule:: tubular
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   tubular.testing
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   tubular.base
+   tubular.capping
+   tubular.dates
+   tubular.imputers
+   tubular.mapping
+   tubular.misc
+   tubular.nominal
+   tubular.numeric
+   tubular.strings

--- a/docs/source/api/tubular.strings.rst
+++ b/docs/source/api/tubular.strings.rst
@@ -1,0 +1,7 @@
+tubular.strings module
+======================
+
+.. automodule:: tubular.strings
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.testing.helpers.rst
+++ b/docs/source/api/tubular.testing.helpers.rst
@@ -1,0 +1,7 @@
+tubular.testing.helpers module
+==============================
+
+.. automodule:: tubular.testing.helpers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/tubular.testing.rst
+++ b/docs/source/api/tubular.testing.rst
@@ -1,0 +1,16 @@
+tubular.testing package
+=======================
+
+.. automodule:: tubular.testing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   tubular.testing.helpers
+   tubular.testing.test_data

--- a/docs/source/api/tubular.testing.test_data.rst
+++ b/docs/source/api/tubular.testing.test_data.rst
@@ -1,0 +1,7 @@
+tubular.testing.test\_data module
+=================================
+
+.. automodule:: tubular.testing.test_data
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,59 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'tubular'
+copyright = '2021, LV GI Data Science Team'
+author = 'LV GI Data Science Team'
+
+# The full version, including alpha/beta/rc tags
+release = '0.2.14'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'sphinx_rtd_theme'
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. tubular documentation master file, created by
+   sphinx-quickstart on Sat May  8 15:39:35 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to tubular's documentation!
+===================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   api
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/examples/numeric/LogTransformer.ipynb
+++ b/examples/numeric/LogTransformer.ipynb
@@ -315,7 +315,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All the argumnets are optional in this transformer. The user can specify;\n",
+    "All the arguments are optional in this transformer. The user can specify;\n",
     "- `columns` the columns to apply the log transform to\n",
     "- `add_1` whether to add 1 to the column before applying the log transform, useful if you have 0s in the column\n",
     "- `drop` to drop the original columns\n",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ pytest-benchmark
 black>=19.10b0
 flake8==3.8.4
 bandit>=1.7.0
+sphinx
+sphinx-rtd-theme

--- a/tests/testing/helpers/test_assert_function_call.py
+++ b/tests/testing/helpers/test_assert_function_call.py
@@ -160,7 +160,7 @@ def test_mocker_patch_object_call(mocker):
 
 
 def test_successful_function_call(mocker):
-    """Test a successful function call with the correct argumnets specified."""
+    """Test a successful function call with the correct arguments specified."""
 
     expected_call_arguments = {
         0: {"args": ("a",), "kwargs": {"other": 1}},

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -37,7 +37,7 @@ class CappingTransformer(BaseTransformer):
         supplied.
 
     weights_column : str or None, default = None
-        Optional weights column argumnet that can be used in combination with quantiles. Not used
+        Optional weights column argument that can be used in combination with quantiles. Not used
         if capping_values is supplied. Allows weighted quantiles to be calculated.
 
     **kwargs
@@ -451,7 +451,7 @@ class OutOfRangeNullTransformer(CappingTransformer):
         in the lists cannot be None. Either one of capping_values or quantiles must be supplied.
 
     weights_column : str or None, default = None
-        Optional weights column argumnet that can be used in combination with quantiles. Not used
+        Optional weights column argument that can be used in combination with quantiles. Not used
         if capping_values is supplied. Allows weighted quantiles to be calculated.
 
     **kwargs

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -368,7 +368,7 @@ class SeriesDtMethodTransformer(BaseTransformer):
         The name of the pandas.DataFrame method to call.
 
     pd_method_kwargs : dict
-        Dictionary of keyword argumnets to call the pd.Series.dt method with.
+        Dictionary of keyword arguments to call the pd.Series.dt method with.
 
     """
 
@@ -508,13 +508,13 @@ class BetweenDatesTransformer(BaseTransformer):
         column_upper].
 
     new_column_name : str
-        new_column_name argumnet passed when initialising the transformer.
+        new_column_name argument passed when initialising the transformer.
 
     lower_inclusive : bool
-        lower_inclusive argumnet passed when initialising the transformer.
+        lower_inclusive argument passed when initialising the transformer.
 
     upper_inclusive : bool
-        upper_inclusive argumnet passed when initialising the transformer.
+        upper_inclusive argument passed when initialising the transformer.
 
     """
 

--- a/tubular/testing/helpers.py
+++ b/tubular/testing/helpers.py
@@ -654,7 +654,7 @@ def assert_function_call_count(mocker, target, attribute, expected_n_calls, **kw
         Expected number of calls to target.attribute.
 
     **kwargs : any
-        Arbitrary keyword argumnets passed on to mocker.patch.object.
+        Arbitrary keyword arguments passed on to mocker.patch.object.
 
     Examples
     --------
@@ -717,7 +717,7 @@ def assert_function_call(mocker, target, attribute, expected_calls_args, **kwarg
         args ('a','b') and keyword args {'c': 1}. See the example section below for more examples.
 
     **kwargs : any
-        Arbitrary keyword argumnets passed on to mocker.patch.object.
+        Arbitrary keyword arguments passed on to mocker.patch.object.
 
     Examples
     --------


### PR DESCRIPTION
Closes #2 

Add sphinx doc files for local build of api documentation

Changes to the standard quickstart-generated files are

* Put Sphinx build directory in an environment variable (see .envrc.example)
* Add api autodoc generated files in docs/source/api
* Use rtd theme
* Add documentation build instructions to README
* Remove link to not-yet-existent read-the-docs page