### PR TITLE
Restore apidoc Makefile command

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,16 @@ help:
 
 .PHONY: help Makefile
 
+# Autodoc creation with apidoc
+apidoc:
+	sphinx-apidoc -fMe ../tubular -o source/api
+	@echo "Auto-generation of API documentation finished;" \
+		"removing unwanted output."
+	rm source/api/modules.rst
+	rm source/api/tubular.rst
+	rm source/api/tubular.testing.rst
+	rm source/api/tubular.testing.test_data.rst
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
Restore apidoc as at commit https://github.com/lvgig/tubular/pull/3/commits/ee68387f7eb068534e4e814dcaa6e4534c3f5727

BUT keep source/api/tubular.testing.helpers.rst, as it was not on the remove list from PR https://github.com/lvgig/tubular/pull/3