### PR TITLE
update MeanResponseTransformer tests so they do not depend on pandas …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 21.9b0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,17 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
+0.3.1 (unreleased)
+------------------
+
+Changed
+^^^^^^^
+- Updated version of ``black`` used in the ``pre-commit-config`` to ``21.9b0``
+
+Fixed
+^^^^^
+- Changed data values used in some tests for MeanResponseTransformer so the test no longer depends on pandas <1.3.0 or >=1.3.0, `required due to change in pandas behaviour with groupby mean <https://pandas.pydata.org/docs/whatsnew/v1.3.0.html#float-result-for-groupby-mean-groupby-median-and-groupby-var>`_
+
 0.3.0 (2021-11-03)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,11 +21,11 @@ Each individual change should have a link to the pull request after the descript
 
 Changed
 ^^^^^^^
-- Updated version of ``black`` used in the ``pre-commit-config`` to ``21.9b0``
+- Updated version of ``black`` used in the ``pre-commit-config`` to ``21.9b0`` `#25 <https://github.com/lvgig/tubular/pull/25>`_
 
 Fixed
 ^^^^^
-- Changed data values used in some tests for MeanResponseTransformer so the test no longer depends on pandas <1.3.0 or >=1.3.0, `required due to change in pandas behaviour with groupby mean <https://pandas.pydata.org/docs/whatsnew/v1.3.0.html#float-result-for-groupby-mean-groupby-median-and-groupby-var>`_
+- Changed data values used in some tests for MeanResponseTransformer so the test no longer depends on pandas <1.3.0 or >=1.3.0, `required due to change in pandas behaviour with groupby mean <https://pandas.pydata.org/docs/whatsnew/v1.3.0.html#float-result-for-groupby-mean-groupby-median-and-groupby-var>`_ `#25 <https://github.com/lvgig/tubular/pull/25>`_
 
 0.3.0 (2021-11-03)
 ------------------

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -197,14 +197,14 @@ class TestFit(object):
         x = MeanResponseTransformer(response_column="a", columns=["b", "d", "f"])
 
         x.fit(df)
-
+        
         ta.classes.test_object_attributes(
             obj=x,
             expected_attributes={
                 "mappings": {
-                    "b": {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6},
-                    "d": {1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6},
-                    "f": {False: 2, True: 5},
+                    "b": {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0, "e": 5.0, "f": 6.0},
+                    "d": {1: 1.0, 2: 2.0, 3: 3.0, 4: 4.0, 5: 5.0, 6: 6.0},
+                    "f": {False: 2.0, True: 5.0},
                 }
             },
             msg="mappings attribute",
@@ -277,7 +277,7 @@ class TestTransform(object):
 
         df = pd.DataFrame(
             {
-                "a": [1, 2, 3, 4, 5, 6],
+                "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
                 "b": [1, 2, 3, 4, 5, 6],
                 "c": ["a", "b", "c", "d", "e", "f"],
                 "d": [1, 2, 3, 4, 5, 6],
@@ -295,7 +295,7 @@ class TestTransform(object):
 
         df = pd.DataFrame(
             {
-                "a": [1, 2, 3, 4, 5, 6, np.NaN],
+                "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, np.NaN],
                 "b": [1, 2, 3, 4, 5, 6, np.NaN],
                 "c": ["a", "b", "c", "d", "e", "f", np.NaN],
             }

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -141,11 +141,7 @@ class TestFit(object):
             call_kwargs == expected_kwargs
         ), "unexpected kwargs in BaseTransformer.fit call"
 
-        expected_pos_args = (
-            x,
-            d.create_MeanResponseTransformer_test_df(),
-            None,
-        )
+        expected_pos_args = (x, d.create_MeanResponseTransformer_test_df(), None)
 
         assert len(expected_pos_args) == len(
             call_pos_args
@@ -197,7 +193,7 @@ class TestFit(object):
         x = MeanResponseTransformer(response_column="a", columns=["b", "d", "f"])
 
         x.fit(df)
-        
+
         ta.classes.test_object_attributes(
             obj=x,
             expected_attributes={
@@ -339,10 +335,7 @@ class TestTransform(object):
         x.fit(df)
 
         expected_call_args = {
-            0: {
-                "args": (d.create_MeanResponseTransformer_test_df(),),
-                "kwargs": {},
-            }
+            0: {"args": (d.create_MeanResponseTransformer_test_df(),), "kwargs": {}}
         }
 
         with ta.functions.assert_function_call(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -248,7 +248,7 @@ def create_MeanResponseTransformer_test_df():
 
     df = pd.DataFrame(
         {
-            "a": [1, 2, 3, 4, 5, 6],
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
             "b": ["a", "b", "c", "d", "e", "f"],
             "c": ["a", "b", "c", "d", "e", "f"],
             "d": [1, 2, 3, 4, 5, 6],


### PR DESCRIPTION
…being above or below v1.3.0

Pandas behaviour changed in 1.3.0; https://pandas.pydata.org/docs/whatsnew/v1.3.0.html#float-result-for-groupby-mean-groupby-median-and-groupby-var