### PR TITLE
Feature/separate x y

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,21 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
+0.3.1 (unreleased)
+------------------
+
+Changed
+^^^^^^^
+- Change ``y`` argument in fit to only accept ``pd.Series`` objects `#26 <https://github.com/lvgig/tubular/pull/26>`_
+- Add new ``_combine_X_y`` method to ``BaseTransformer`` which cbinds X and y `#26 <https://github.com/lvgig/tubular/pull/26>`_
+- Update ``MeanResponseTransformer`` to use ``y`` arg in ``fit`` and remove setting ``response_column`` in init `#26 <https://github.com/lvgig/tubular/pull/26>`_
+- Update ``OrdinalEncoderTransformer`` to use ``y`` arg in ``fit`` and remove setting ``response_column`` in init `#26 <https://github.com/lvgig/tubular/pull/26>`_
+- Update ``NearestMeanResponseImputer`` to use ``y`` arg in ``fit`` and remove setting ``response_column`` in init `#26 <https://github.com/lvgig/tubular/pull/26>`_
+
+Fixed
+^^^^^
+- ``BaseTransformer`` now correctly raises ``TypeError`` exceptions instead of ``ValueError`` when input values are the wrong type `#26 <https://github.com/lvgig/tubular/pull/26>`_
+
 0.3.0 (2021-11-03)
 ------------------
 

--- a/tests/base/test_BaseTransformer.py
+++ b/tests/base/test_BaseTransformer.py
@@ -207,7 +207,7 @@ class TestFit(object):
 
         with pytest.raises(ValueError, match=re.escape("y is empty; (0,)")):
 
-            x.fit(X=df, y=pandas.Series(name="b"))
+            x.fit(X=df, y=pandas.Series(name="b", dtype=object))
 
 
 class TestTransform(object):

--- a/tests/base/test_BaseTransformer.py
+++ b/tests/base/test_BaseTransformer.py
@@ -91,14 +91,14 @@ class TestInit(object):
     def test_verbose_non_bool_error(self):
         """Test an error is raised if verbose is not specified as a bool."""
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="verbose must be a bool"):
 
             BaseTransformer(verbose=1)
 
     def test_copy_non_bool_error(self):
         """Test an error is raised if copy is not specified as a bool."""
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="copy must be a bool"):
 
             BaseTransformer(copy=1)
 
@@ -112,14 +112,24 @@ class TestInit(object):
     def test_columns_list_element_error(self):
         """Test an error is raised if columns list contains non-string elements."""
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "each element of columns should be a single (string) column name"
+            ),
+        ):
 
             BaseTransformer(columns=[[], "a"])
 
     def test_columns_non_string_error(self):
         """Test an error is raised if columns is not passed as a string."""
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "columns must be a string or list with the columns to be pre-processed (if specified)"
+            ),
+        ):
 
             BaseTransformer(columns=1)
 
@@ -152,7 +162,7 @@ class TestFit(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
 
             x.fit("a")
 
@@ -240,7 +250,7 @@ class TestTransform(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
 
             x.transform(X=[1, 2, 3, 4, 5, 6])
 
@@ -303,7 +313,7 @@ class TestColumnsCheck(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
 
             x.columns_check(X=[1, 2, 3, 4, 5, 6])
 
@@ -329,7 +339,7 @@ class TestColumnsCheck(object):
 
         x.columns = "a"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="self.columns should be a list"):
 
             x.columns_check(X=df)
 
@@ -360,7 +370,7 @@ class TestColumnsSetOrCheck(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
 
             x.columns_set_or_check(X=[1, 2, 3, 4, 5, 6])
 

--- a/tests/base/test_BaseTransformer.py
+++ b/tests/base/test_BaseTransformer.py
@@ -156,25 +156,16 @@ class TestFit(object):
 
             x.fit("a")
 
-    def test_y_multi_col_df_error(self):
-        """Test an error is raised if y is passed as a multi column pd.DataFrame."""
-
-        df = d.create_df_1()
-
-        x = BaseTransformer(columns="a")
-
-        with pytest.raises(ValueError):
-
-            x.fit(X=df, y=df)
-
     def test_non_pd_type_error(self):
-        """Test an error is raised if y is not passed as a pd.DataFrame or pd.Series."""
+        """Test an error is raised if y is not passed as a pd.Series."""
 
         df = d.create_df_1()
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(
+            TypeError, match="unexpected type for y, should be a pd.Series"
+        ):
 
             x.fit(X=df, y=[1, 2, 3, 4, 5, 6])
 
@@ -207,23 +198,16 @@ class TestFit(object):
 
             x.fit(X=df)
 
-    @pytest.mark.parametrize(
-        "y, error_message",
-        [
-            (pandas.Series(name="b"), "y is empty; (0,)"),
-            (pandas.DataFrame(columns=["b"]), "y is empty; (0, 1)"),
-        ],
-    )
-    def test_y_no_rows_error(self, y, error_message):
+    def test_y_no_rows_error(self):
         """Test an error is raised if X has no rows."""
 
         x = BaseTransformer(columns="a")
 
         df = pandas.DataFrame({"a": 1}, index=[0])
 
-        with pytest.raises(ValueError, match=re.escape(error_message)):
+        with pytest.raises(ValueError, match=re.escape("y is empty; (0,)")):
 
-            x.fit(X=df, y=y)
+            x.fit(X=df, y=pandas.Series(name="b"))
 
 
 class TestTransform(object):

--- a/tests/imputers/test_NearestMeanResponseImputer.py
+++ b/tests/imputers/test_NearestMeanResponseImputer.py
@@ -16,7 +16,7 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=NearestMeanResponseImputer.__init__,
-            expected_arguments=["self", "response_column", "columns"],
+            expected_arguments=["self", "columns"],
             expected_default_values=(None,),
         )
 
@@ -34,7 +34,7 @@ class TestInit(object):
     def test_inheritance(self):
         """Test that NearestMeanResponseImputer inherits from BaseImputer."""
 
-        x = NearestMeanResponseImputer(response_column="c", columns=None)
+        x = NearestMeanResponseImputer(columns=None)
 
         ta.classes.assert_inheritance(x, tubular.imputers.BaseImputer)
 
@@ -49,33 +49,7 @@ class TestInit(object):
             mocker, tubular.base.BaseTransformer, "__init__", expected_call_args
         ):
 
-            NearestMeanResponseImputer(
-                response_column="c",
-                columns=None,
-                verbose=True,
-                copy=True,
-            )
-
-    def test_response_column_not_str_error(self):
-        """Test that an exception is raised if response_column is not str"""
-
-        with pytest.raises(TypeError, match="response_column must be a str"):
-
-            NearestMeanResponseImputer(response_column=0)
-
-    def test_values_passed_in_init_set_to_attribute(self):
-        """Test that the values passed in init are saved in an attribute of the same name."""
-
-        x = NearestMeanResponseImputer(
-            response_column="c",
-            columns="a",
-        )
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={"response_column": "c"},
-            msg="Attributes for NearestMeanResponseImputer set in init",
-        )
+            NearestMeanResponseImputer(columns=None, verbose=True, copy=True)
 
 
 class TestFit(object):
@@ -87,7 +61,7 @@ class TestFit(object):
         ta.functions.test_function_arguments(
             func=NearestMeanResponseImputer.fit,
             expected_arguments=["self", "X", "y"],
-            expected_default_values=(None,),
+            expected_default_values=None,
         )
 
     def test_super_fit_called(self, mocker):
@@ -95,13 +69,13 @@ class TestFit(object):
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
         expected_call_args = {
             0: {
                 "args": (
                     d.create_NearestMeanResponseImputer_test_df(),
-                    None,
+                    d.create_NearestMeanResponseImputer_test_df()["c"],
                 ),
                 "kwargs": {},
             }
@@ -111,33 +85,18 @@ class TestFit(object):
             mocker, tubular.base.BaseTransformer, "fit", expected_call_args
         ):
 
-            x.fit(df)
-
-    def test_non_numeric_response_column_error(self):
-        """Test an error is raised if response_column is non-numeric"""
-
-        df = pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5], "b": [5, 4, 3, 2, 1], "c": ["a", "b", "c", "d", "e"]}
-        )
-
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
-
-        with pytest.raises(
-            ValueError, match="dtypes in response_column must be numeric."
-        ):
-
-            x.fit(df)
+            x.fit(df, df["c"])
 
     def test_null_values_in_response_error(self):
         """Test an error is raised if the response column contains null entries."""
 
         df = d.create_df_3()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        with pytest.raises(ValueError, match=r"Response column \(c\) has null values."):
+        with pytest.raises(ValueError, match="y has 1 null values"):
 
-            x.fit(df)
+            x.fit(df, df["c"])
 
     def test_columns_with_no_nulls_error(self):
         """Test an error is raised if a non-response column contains no nulls."""
@@ -146,23 +105,23 @@ class TestFit(object):
             {"a": [1, 2, 3, 4, 5], "b": [5, 4, 3, 2, 1], "c": [3, 2, 1, 4, 5]}
         )
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
         with pytest.raises(
             ValueError,
             match="Column a has no missing values, cannot use this transformer.",
         ):
 
-            x.fit(df)
+            x.fit(df, df["c"])
 
     def test_fit_returns_self(self):
         """Test fit returns self?"""
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x_fitted = x.fit(df)
+        x_fitted = x.fit(df, df["c"])
 
         assert (
             x_fitted is x
@@ -173,9 +132,9 @@ class TestFit(object):
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x.fit(df)
+        x.fit(df, df["c"])
 
         ta.equality.assert_equal_dispatch(
             expected=d.create_NearestMeanResponseImputer_test_df(),
@@ -188,9 +147,9 @@ class TestFit(object):
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x.fit(df)
+        x.fit(df, df["c"])
 
         ta.classes.test_object_attributes(
             obj=x,
@@ -211,9 +170,9 @@ class TestFit(object):
             }
         )
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x.fit(df)
+        x.fit(df, df["c"])
 
         ta.classes.test_object_attributes(
             obj=x,
@@ -274,9 +233,9 @@ class TestTransform(object):
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x.fit(df)
+        x.fit(df, df["c"])
 
         expected_call_args = {0: {"args": (["impute_values_"],), "kwargs": {}}}
 
@@ -291,15 +250,12 @@ class TestTransform(object):
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x.fit(df)
+        x.fit(df, df["c"])
 
         expected_call_args = {
-            0: {
-                "args": (d.create_NearestMeanResponseImputer_test_df(),),
-                "kwargs": {},
-            }
+            0: {"args": (d.create_NearestMeanResponseImputer_test_df(),), "kwargs": {}}
         }
 
         with ta.functions.assert_function_call(
@@ -317,7 +273,7 @@ class TestTransform(object):
     def test_nulls_imputed_correctly(self, df, expected):
         """Test missing values are filled with the correct values."""
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
         # set the impute values dict directly rather than fitting x on df so test works with helpers
         x.impute_values_ = {"a": 2.0, "b": 3.0}
@@ -339,7 +295,7 @@ class TestTransform(object):
     def test_nulls_imputed_correctly2(self, df, expected):
         """Test missing values are filled with the correct values - and unrelated columns are unchanged."""
 
-        x = NearestMeanResponseImputer(response_column="c", columns="a")
+        x = NearestMeanResponseImputer(columns="a")
 
         # set the impute values dict directly rather than fitting x on df so test works with helpers
         x.impute_values_ = {"a": 2.0}
@@ -361,7 +317,7 @@ class TestTransform(object):
     def test_nulls_imputed_correctly3(self, df, expected):
         """Test missing values are filled with the correct values - with median value from separate dataframe."""
 
-        x = NearestMeanResponseImputer(response_column="c", columns="a")
+        x = NearestMeanResponseImputer(columns="a")
 
         # set the impute values dict directly rather than fitting x on df so test works with helpers
         x.impute_values_ = {"a": 2.0}
@@ -379,13 +335,13 @@ class TestTransform(object):
 
         df = d.create_NearestMeanResponseImputer_test_df()
 
-        x = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x.fit(df)
+        x.fit(df, df["c"])
 
-        x2 = NearestMeanResponseImputer(response_column="c", columns=["a", "b"])
+        x2 = NearestMeanResponseImputer(columns=["a", "b"])
 
-        x2.fit(df)
+        x2.fit(df, df["c"])
 
         x2.transform(df)
 

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -16,7 +16,7 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=MeanResponseTransformer.__init__,
-            expected_arguments=["self", "response_column", "columns", "weights_column"],
+            expected_arguments=["self", "columns", "weights_column"],
             expected_default_values=(None, None),
         )
 
@@ -43,9 +43,7 @@ class TestInit(object):
 
         spy = mocker.spy(tubular.base.BaseTransformer, "__init__")
 
-        x = MeanResponseTransformer(
-            response_column="a", columns=None, verbose=True, copy=True
-        )
+        x = MeanResponseTransformer(columns=None, verbose=True, copy=True)
 
         assert (
             spy.call_count == 1
@@ -71,13 +69,6 @@ class TestInit(object):
             expected_pos_args == call_pos_args
         ), "unexpected positional args in BaseTransformer.__init__ call"
 
-    def test_response_column_not_str_error(self):
-        """Test that an exception is raised if response_column is not a str."""
-
-        with pytest.raises(TypeError, match="response_column should be a str"):
-
-            MeanResponseTransformer(response_column=1)
-
     def test_weights_column_not_str_error(self):
         """Test that an exception is raised if weights_column is not a str."""
 
@@ -85,23 +76,14 @@ class TestInit(object):
 
             MeanResponseTransformer(response_column="a", weights_column=1)
 
-    def test_response_weights_column_equal_error(self):
-        """Test that an exception is raised if weights_column and response_column are equal."""
-
-        with pytest.raises(
-            ValueError, match="weights_column and response_column are the same column"
-        ):
-
-            MeanResponseTransformer(response_column="a", weights_column="a")
-
     def test_values_passed_in_init_set_to_attribute(self):
         """Test that the values passed in init are saved in an attribute of the same name."""
 
-        x = MeanResponseTransformer(response_column="aaa")
+        x = MeanResponseTransformer(weights_column="aaa")
 
         ta.classes.test_object_attributes(
             obj=x,
-            expected_attributes={"response_column": "aaa"},
+            expected_attributes={"weights_column": "aaa"},
             msg="Attributes for MeanResponseTransformer set in init",
         )
 
@@ -115,7 +97,7 @@ class TestFit(object):
         ta.functions.test_function_arguments(
             func=MeanResponseTransformer.fit,
             expected_arguments=["self", "X", "y"],
-            expected_default_values=(None,),
+            expected_default_values=None,
         )
 
     def test_super_fit_called(self, mocker):
@@ -123,11 +105,11 @@ class TestFit(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns="b")
+        x = MeanResponseTransformer(columns="b")
 
         spy = mocker.spy(tubular.base.BaseTransformer, "fit")
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         assert spy.call_count == 1, "unexpected number of calls to BaseTransformer.fit"
 
@@ -144,21 +126,17 @@ class TestFit(object):
         expected_pos_args = (
             x,
             d.create_MeanResponseTransformer_test_df(),
-            None,
+            d.create_MeanResponseTransformer_test_df()["a"],
         )
 
         assert len(expected_pos_args) == len(
             call_pos_args
         ), "unexpected # positional args in BaseTransformer.fit call"
 
-        assert (
-            expected_pos_args[0] == call_pos_args[0]
-        ), "unexpected 1st positional arg in BaseTransformer.fit call"
-
         ta.equality.assert_equal_dispatch(
-            expected_pos_args[1:3],
-            call_pos_args[1:3],
-            "unexpected 2nd, 3rd positional arg in BaseTransformer.fit call",
+            expected_pos_args,
+            call_pos_args,
+            "unexpected arguments in BaseTransformer.fit call",
         )
 
     def test_fit_returns_self(self):
@@ -166,9 +144,9 @@ class TestFit(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns="b")
+        x = MeanResponseTransformer(columns="b")
 
-        x_fitted = x.fit(df)
+        x_fitted = x.fit(df, df["a"])
 
         assert (
             x_fitted is x
@@ -179,9 +157,9 @@ class TestFit(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns="b")
+        x = MeanResponseTransformer(columns="b")
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         ta.equality.assert_equal_dispatch(
             expected=d.create_MeanResponseTransformer_test_df(),
@@ -194,9 +172,9 @@ class TestFit(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns=["b", "d", "f"])
+        x = MeanResponseTransformer(columns=["b", "d", "f"])
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         ta.classes.test_object_attributes(
             obj=x,
@@ -215,11 +193,9 @@ class TestFit(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(
-            response_column="a", weights_column="e", columns=["b", "d", "f"]
-        )
+        x = MeanResponseTransformer(weights_column="e", columns=["b", "d", "f"])
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         ta.classes.test_object_attributes(
             obj=x,
@@ -233,40 +209,27 @@ class TestFit(object):
             msg="mappings attribute",
         )
 
-    def test_response_column_missing_error(self):
-        """Test that an exception is raised if response_column is not present in data."""
-
-        df = d.create_MeanResponseTransformer_test_df()
-
-        x = MeanResponseTransformer(response_column="z", columns=["b", "d", "f"])
-
-        with pytest.raises(ValueError, match="response z not in X"):
-
-            x.fit(df)
-
     def test_weights_column_missing_error(self):
         """Test that an exception is raised if weights_column is specified but not present in data for fit."""
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(
-            response_column="a", weights_column="z", columns=["b", "d", "f"]
-        )
+        x = MeanResponseTransformer(weights_column="z", columns=["b", "d", "f"])
 
         with pytest.raises(ValueError, match="weights column z not in X"):
 
-            x.fit(df)
+            x.fit(df, df["a"])
 
     def test_response_column_nulls_error(self):
         """Test that an exception is raised if nulls are present in response_column."""
 
         df = d.create_df_4()
 
-        x = MeanResponseTransformer(response_column="a", columns=["b"])
+        x = MeanResponseTransformer(columns=["b"])
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="y has 1 null values"):
 
-            x.fit(df)
+            x.fit(df, df["a"])
 
 
 class TestTransform(object):
@@ -317,9 +280,9 @@ class TestTransform(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns="b")
+        x = MeanResponseTransformer(columns="b")
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         expected_call_args = {0: {"args": (["mappings"],), "kwargs": {}}}
 
@@ -334,15 +297,12 @@ class TestTransform(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns="b")
+        x = MeanResponseTransformer(columns="b")
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         expected_call_args = {
-            0: {
-                "args": (d.create_MeanResponseTransformer_test_df(),),
-                "kwargs": {},
-            }
+            0: {"args": (d.create_MeanResponseTransformer_test_df(),), "kwargs": {}}
         }
 
         with ta.functions.assert_function_call(
@@ -360,13 +320,13 @@ class TestTransform(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns="b")
+        x = MeanResponseTransformer(columns="b")
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
-        x2 = MeanResponseTransformer(response_column="a", columns="b")
+        x2 = MeanResponseTransformer(columns="b")
 
-        x2.fit(df)
+        x2.fit(df, df["a"])
 
         x2.transform(df)
 
@@ -407,9 +367,9 @@ class TestTransform(object):
 
         df = d.create_MeanResponseTransformer_test_df()
 
-        x = MeanResponseTransformer(response_column="a", columns=["b", "d", "f"])
+        x = MeanResponseTransformer(columns=["b", "d", "f"])
 
-        x.fit(df)
+        x.fit(df, df["a"])
 
         df["b"] = "z"
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -55,7 +55,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(verbose, bool):
 
-            raise ValueError("verbose must be a bool")
+            raise TypeError("verbose must be a bool")
 
         else:
 
@@ -86,21 +86,21 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
                     if not isinstance(c, str):
 
-                        raise ValueError(
-                            "each element of columns should be a single column name"
+                        raise TypeError(
+                            "each element of columns should be a single (string) column name"
                         )
 
                 self.columns = columns
 
             else:
 
-                raise ValueError(
+                raise TypeError(
                     "columns must be a string or list with the columns to be pre-processed (if specified)"
                 )
 
         if not isinstance(copy, bool):
 
-            raise ValueError("copy must be a bool")
+            raise TypeError("copy must be a bool")
 
         else:
 
@@ -247,7 +247,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(X, pd.DataFrame):
 
-            raise ValueError("X should be a pd.DataFrame")
+            raise TypeError("X should be a pd.DataFrame")
 
         if self.columns is None:
 
@@ -255,7 +255,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(self.columns, list):
 
-            raise ValueError("self.columns should be a list")
+            raise TypeError("self.columns should be a list")
 
         for c in self.columns:
 
@@ -277,7 +277,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(X, pd.DataFrame):
 
-            raise ValueError("X should be a pd.DataFrame")
+            raise TypeError("X should be a pd.DataFrame")
 
         if self.columns is None:
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -4,6 +4,7 @@ from. These transformers contain key checks to be applied in all cases.
 """
 
 import pandas as pd
+import warnings
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils.validation import check_is_fitted
 
@@ -143,6 +144,48 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
                 raise ValueError(f"y is empty; {y.shape}")
 
         return self
+
+    def _combine_X_y(self, X, y):
+        """Combine X and y by adding a new column with the values of y to a copy of X.
+
+        The new column response column will be called `_temporary_response`.
+
+        This method can be used by transformers that need to use the response, y, together
+        with the explanatory variables, X, in their `fit` methods.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Data containing explanatory variables.
+
+        y : pd.Series
+            Response variable.
+
+        """
+
+        if not isinstance(X, pd.DataFrame):
+
+            raise TypeError("X should be a pd.DataFrame")
+
+        if not isinstance(y, pd.Series):
+
+            raise TypeError("y should be a pd.Series")
+
+        if X.shape[0] != y.shape[0]:
+
+            raise ValueError(
+                f"X and y have different numbers of rows ({X.shape[0]} vs {y.shape[0]})"
+            )
+
+        if not (X.index == y.index).all():
+
+            warnings.warn("X and y do not have equal indexes")
+
+        X_y = X.copy()
+
+        X_y["_temporary_response"] = y.values
+
+        return X_y
 
     def transform(self, X):
         """Base transformer transform method; checks X type (pandas DataFrame only) and copies data if requested.

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -134,21 +134,9 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if y is not None:
 
-            if isinstance(y, pd.DataFrame):
+            if not isinstance(y, pd.Series):
 
-                if y.shape[1] > 1:
-
-                    raise ValueError(
-                        "multi-column DataFrame passed for y, expecting 1 column"
-                    )
-
-            elif isinstance(y, pd.Series):
-
-                pass
-
-            else:
-
-                raise ValueError("unexpected type for y")
+                raise TypeError("unexpected type for y, should be a pd.Series")
 
             if not y.shape[0] > 0:
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -595,9 +595,6 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
     Parameters
     ----------
-    response_column : str
-        Response column to use to encode the categorical levels.
-
     columns : None or str or list, default = None
         Columns to transform, if the default of None is supplied all object and category
         columns in X are used.
@@ -610,9 +607,6 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
     Attributes
     ----------
-    response_column : str
-        Response column to use to encode the categorical levels.
-
     weights_column : str or None
         Weights column to use when calculating the mean response.
 
@@ -622,11 +616,7 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
     """
 
-    def __init__(self, response_column, columns=None, weights_column=None, **kwargs):
-
-        if type(response_column) is not str:
-
-            raise TypeError("response_column should be a str")
+    def __init__(self, columns=None, weights_column=None, **kwargs):
 
         if weights_column is not None:
 
@@ -634,18 +624,11 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
                 raise TypeError("weights_column should be a str")
 
-            if weights_column == response_column:
-
-                raise ValueError(
-                    "weights_column and response_column are the same column"
-                )
-
-        self.response_column = response_column
         self.weights_column = weights_column
 
         BaseNominalTransformer.__init__(self, columns=columns, **kwargs)
 
-    def fit(self, X, y=None):
+    def fit(self, X, y):
         """Identify mapping of categorical levels to rank-ordered integer values by target-mean in ascending order.
 
         If the user specified the weights_column arg in when initialising the transformer
@@ -657,8 +640,8 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
             Data to with catgeorical variable columns to transform and response_column column
             specified when object was initialised.
 
-        y : None or pd.DataFrame or pd.Series, default = None
-            Optional argument only required for the transformer to work with sklearn pipelines.
+        y : pd.Series
+            Response column or target.
 
         """
 
@@ -666,23 +649,20 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
         self.mappings = {}
 
-        if self.response_column not in X.columns.values:
-
-            raise ValueError(f"response {self.response_column} not in X")
-
         if self.weights_column is not None:
 
             if self.weights_column not in X.columns.values:
 
                 raise ValueError(f"weights column {self.weights_column} not in X")
 
-        response_null_count = X[self.response_column].isnull().sum()
+        response_null_count = y.isnull().sum()
 
         if response_null_count > 0:
 
-            raise ValueError(
-                f"{self.response_column} in X has {response_null_count} null values"
-            )
+            raise ValueError(f"y has {response_null_count} null values")
+
+        X_y = self._combine_X_y(X, y)
+        response_column = "_temporary_response"
 
         for c in self.columns:
 
@@ -690,7 +670,7 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
                 # get the indexes of the sorted target mean-encoded dict
                 _idx_target_mean = list(
-                    X.groupby([c])[self.response_column]
+                    X_y.groupby([c])[response_column]
                     .mean()
                     .sort_values(ascending=True, kind="mergesort")
                     .index
@@ -707,16 +687,13 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
             else:
 
-                groupby_sum = X.groupby([c])[
-                    [self.response_column, self.weights_column]
+                groupby_sum = X_y.groupby([c])[
+                    [response_column, self.weights_column]
                 ].sum()
 
                 # get the indexes of the sorted target mean-encoded dict
                 _idx_target_mean = list(
-                    (
-                        groupby_sum[self.response_column]
-                        / groupby_sum[self.weights_column]
-                    )
+                    (groupby_sum[response_column] / groupby_sum[self.weights_column])
                     .sort_values(ascending=True, kind="mergesort")
                     .index
                 )


### PR DESCRIPTION
Update relevant transformers to use `X` and `y` in the `fit` methods rather than passing a `response_column` variable when initialising the objects