### PR TITLE
Fixes #43: Debug kwargs removal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,14 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
+
+0.X.0 (2022-11-17)
+------------------
+
+Changed
+^^^^^^^
+- Removed kwargs argument from ``BaseTransformer`` due to its parent classes not needing it.  This was generating that wrong arguments (typos or unrequired) were passed silently. For instance, in case of the wrong ``columns`` the default behaviour was to use all possible columns (depending on the actual transformer), which generated undesirable effects. `#43 <https://github.com/lvgig/tubular/pull/43>`_
+
 0.3.2 (2022-01-13)
 ------------------
 

--- a/tests/base/test_DataFrameMethodTransformer.py
+++ b/tests/base/test_DataFrameMethodTransformer.py
@@ -23,8 +23,10 @@ class TestInit(object):
                 "columns",
                 "pd_method_kwargs",
                 "drop_original",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=({}, False),
+            expected_default_values=(None, False, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -21,8 +21,10 @@ class TestInit(object):
                 "capping_values",
                 "quantiles",
                 "weights_column",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=(None, None, None),
+            expected_default_values=(None, None, None, True, False),
         )
 
     @pytest.mark.parametrize(
@@ -193,6 +195,8 @@ class TestInit(object):
                 "weights_column": None,
                 "capping_values": {},
                 "_replacement_values": {},
+                "copy": True,
+                "verbose": False
             },
             msg="quantiles attribute for CappingTransformer set in init",
         )
@@ -353,7 +357,8 @@ class TestFit(object):
         df = d.create_df_9()
 
         x = CappingTransformer(
-            quantiles={"a": [0.1, 1], "b": [0.5, None]}, weights_column="c"
+            quantiles={"a": [0.1, 1], "b": [0.5, None]}, weights_column="c",
+            copy=True, verbose=False
         )
 
         expected_call_args = {0: {"args": (d.create_df_9(), None), "kwargs": {}}}
@@ -370,7 +375,8 @@ class TestFit(object):
         df = d.create_df_9()
 
         x = CappingTransformer(
-            quantiles={"a": [0.1, 1], "b": [0.5, None]}, weights_column="c"
+            quantiles={"a": [0.1, 1], "b": [0.5, None]}, weights_column="c",
+            copy=True, verbose=False
         )
 
         expected_call_args = {
@@ -406,7 +412,8 @@ class TestFit(object):
 
         df = d.create_df_9()
 
-        x = CappingTransformer(quantiles={"a": [0.1, 1], "b": [0.5, None]})
+        x = CappingTransformer(quantiles={"a": [0.1, 1], "b": [0.5, None]},
+                               copy=True, verbose=False)
 
         expected_call_args = {
             0: {
@@ -435,7 +442,8 @@ class TestFit(object):
         df = d.create_df_9()
 
         x = CappingTransformer(
-            quantiles={"a": [0.1, 1], "b": [0.5, None]}, weights_column=weights_column
+            quantiles={"a": [0.1, 1], "b": [0.5, None]}, weights_column=weights_column,
+            copy=True, verbose=False
         )
 
         mocked_return_values = [["aaaa", "bbbb"], [1234, None]]
@@ -470,7 +478,8 @@ class TestFit(object):
         df = d.create_df_9()
 
         x = CappingTransformer(
-            quantiles={"a": quantiles}, weights_column=weights_column
+            quantiles={"a": quantiles}, weights_column=weights_column,
+            copy=True, verbose=False
         )
 
         try:

--- a/tests/dates/test_BetweenDatesTransformer.py
+++ b/tests/dates/test_BetweenDatesTransformer.py
@@ -25,8 +25,10 @@ class TestInit(object):
                 "new_column_name",
                 "lower_inclusive",
                 "upper_inclusive",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=(True, True),
+            expected_default_values=(True, True, True, False),
         )
 
     def test_inheritance(self):

--- a/tests/dates/test_DateDiffLeapYearTransformer.py
+++ b/tests/dates/test_DateDiffLeapYearTransformer.py
@@ -86,8 +86,10 @@ class TestInit(object):
                 "new_column_name",
                 "drop_cols",
                 "missing_replacement",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=(None,),
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/dates/test_SeriesDtMethodTransformer.py
+++ b/tests/dates/test_SeriesDtMethodTransformer.py
@@ -20,8 +20,10 @@ class TestInit(object):
                 "pd_method_name",
                 "column",
                 "pd_method_kwargs",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=({},),
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/dates/test_ToDatetimeTransformer.py
+++ b/tests/dates/test_ToDatetimeTransformer.py
@@ -23,8 +23,10 @@ class TestInit(object):
                 "column",
                 "new_column_name",
                 "to_datetime_kwargs",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=({},),
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -14,8 +14,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=ArbitraryImputer.__init__,
-            expected_arguments=["self", "impute_value", "columns"],
-            expected_default_values=None,
+            expected_arguments=["self", "impute_value", "columns", "copy", "verbose"],
+            expected_default_values=(True, False),
         )
 
     def test_class_methods(self):

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -16,8 +16,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=MeanImputer.__init__,
-            expected_arguments=["self", "columns"],
-            expected_default_values=(None,),
+            expected_arguments=["self", "columns", "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -16,8 +16,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=MedianImputer.__init__,
-            expected_arguments=["self", "columns"],
-            expected_default_values=(None,),
+            expected_arguments=["self", "columns", "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -16,8 +16,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=ModeImputer.__init__,
-            expected_arguments=["self", "columns"],
-            expected_default_values=(None,),
+            expected_arguments=["self", "columns", "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/imputers/test_NearestMeanResponseImputer.py
+++ b/tests/imputers/test_NearestMeanResponseImputer.py
@@ -16,14 +16,14 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=NearestMeanResponseImputer.__init__,
-            expected_arguments=["self", "columns"],
-            expected_default_values=(None,),
+            expected_arguments=["self", "columns", "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):
         """Test that NearestMeanResponseImputer has fit and transform methods."""
 
-        x = NearestMeanResponseImputer(response_column="c", columns=None)
+        x = NearestMeanResponseImputer(columns=None)
 
         ta.classes.test_object_method(obj=x, expected_method="fit", msg="fit")
 

--- a/tests/imputers/test_NullIndicator.py
+++ b/tests/imputers/test_NullIndicator.py
@@ -16,8 +16,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=NullIndicator.__init__,
-            expected_arguments=["self", "columns"],
-            expected_default_values=(None,),
+            expected_arguments=["self", "columns", "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -14,8 +14,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=BaseMappingTransformer.__init__,
-            expected_arguments=["self", "mappings"],
-            expected_default_values=None,
+            expected_arguments=["self", "mappings", "copy", "verbose"],
+            expected_default_values=(True, False)
         )
 
     def test_class_methods(self):

--- a/tests/misc/test_SetValueTransformer.py
+++ b/tests/misc/test_SetValueTransformer.py
@@ -14,8 +14,8 @@ class TestInit:
 
         ta.functions.test_function_arguments(
             func=SetValueTransformer.__init__,
-            expected_arguments=["self", "columns", "value"],
-            expected_default_values=None,
+            expected_arguments=["self", "columns", "value", "copy", "verbose"],
+            expected_default_values=(True, False),
         )
 
     def test_inheritance(self):

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -23,8 +23,10 @@ class TestInit(object):
                 "weight",
                 "rare_level_name",
                 "record_rare_levels",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=(None, 0.01, None, "rare", True),
+            expected_default_values=(None, 0.01, None, "rare", True, True, False),
         )
 
     def test_class_methods(self):
@@ -203,7 +205,7 @@ class TestFit(object):
 
         df = d.create_df_6()
 
-        x = GroupRareLevelsTransformer(columns=["b"], cut_off_percent=0.3, weights="a")
+        x = GroupRareLevelsTransformer(columns=["b"], cut_off_percent=0.3, weight="a")
 
         x.fit(df)
 
@@ -218,7 +220,7 @@ class TestFit(object):
 
         df = d.create_df_6()
 
-        x = GroupRareLevelsTransformer(columns=["c"], cut_off_percent=0.2, weights="a")
+        x = GroupRareLevelsTransformer(columns=["c"], cut_off_percent=0.2, weight="a")
 
         x.fit(df)
 

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -16,14 +16,14 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=MeanResponseTransformer.__init__,
-            expected_arguments=["self", "columns", "weights_column"],
-            expected_default_values=(None, None),
+            expected_arguments=["self", "columns", "weights_column", "copy", "verbose"],
+            expected_default_values=(None, None, True, False),
         )
 
     def test_class_methods(self):
         """Test that MeanResponseTransformer has fit and transform methods."""
 
-        x = MeanResponseTransformer(response_column="a")
+        x = MeanResponseTransformer()
 
         ta.classes.test_object_method(obj=x, expected_method="fit", msg="fit")
 
@@ -34,7 +34,7 @@ class TestInit(object):
     def test_inheritance(self):
         """Test that NominalToIntegerTransformer inherits from BaseNominalTransformer."""
 
-        x = MeanResponseTransformer(response_column="a")
+        x = MeanResponseTransformer()
 
         ta.classes.assert_inheritance(x, tubular.nominal.BaseNominalTransformer)
 
@@ -74,7 +74,7 @@ class TestInit(object):
 
         with pytest.raises(TypeError, match="weights_column should be a str"):
 
-            MeanResponseTransformer(response_column="a", weights_column=1)
+            MeanResponseTransformer(weights_column=1)
 
     def test_values_passed_in_init_set_to_attribute(self):
         """Test that the values passed in init are saved in an attribute of the same name."""
@@ -345,7 +345,7 @@ class TestTransform(object):
     def test_expected_output(self, df, expected):
         """Test that the output is expected from transform."""
 
-        x = MeanResponseTransformer(response_column="a", columns=["b", "d", "f"])
+        x = MeanResponseTransformer(columns=["b", "d", "f"])
 
         # set the impute values dict directly rather than fitting x on df so test works with helpers
         x.mappings = {

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -15,8 +15,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=NominalToIntegerTransformer.__init__,
-            expected_arguments=["self", "columns", "start_encoding"],
-            expected_default_values=(None, 0),
+            expected_arguments=["self", "columns", "start_encoding", "copy", "verbose"],
+            expected_default_values=(None, 0, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -15,14 +15,14 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=OrdinalEncoderTransformer.__init__,
-            expected_arguments=["self", "columns", "weights_column"],
-            expected_default_values=(None, None),
+            expected_arguments=["self", "columns", "weights_column", "copy", "verbose"],
+            expected_default_values=(None, None, True, False),
         )
 
     def test_class_methods(self):
         """Test that OrdinalEncoderTransformer has fit and transform methods."""
 
-        x = OrdinalEncoderTransformer(response_column="a")
+        x = OrdinalEncoderTransformer()
 
         ta.classes.test_object_method(obj=x, expected_method="fit", msg="fit")
 
@@ -33,7 +33,7 @@ class TestInit(object):
     def test_inheritance(self):
         """Test that NominalToIntegerTransformer inherits from BaseNominalTransformer."""
 
-        x = OrdinalEncoderTransformer(response_column="a")
+        x = OrdinalEncoderTransformer()
 
         ta.classes.assert_inheritance(x, tubular.nominal.BaseNominalTransformer)
         ta.classes.assert_inheritance(x, tubular.mapping.BaseMappingTransformMixin)

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -17,8 +17,8 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=CutTransformer.__init__,
-            expected_arguments=["self", "column", "new_column_name", "cut_kwargs"],
-            expected_default_values=({},),
+            expected_arguments=["self", "column", "new_column_name", "cut_kwargs", "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/numeric/test_InteractionTransformer.py
+++ b/tests/numeric/test_InteractionTransformer.py
@@ -22,8 +22,10 @@ class TestInit(object):
                 "columns",
                 "min_degree",
                 "max_degree",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=(2, 2),
+            expected_default_values=(2, 2, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/numeric/test_LogTransformer.py
+++ b/tests/numeric/test_LogTransformer.py
@@ -17,8 +17,9 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=LogTransformer.__init__,
-            expected_arguments=["self", "columns", "base", "add_1", "drop", "suffix"],
-            expected_default_values=(None, False, True, "log"),
+            expected_arguments=["self", "columns", "base", "add_1", "drop", "suffix",
+                                "copy", "verbose"],
+            expected_default_values=(None, False, True, "log", True, False),
         )
 
     def test_base_type_error(self):
@@ -32,7 +33,6 @@ class TestInit(object):
             LogTransformer(
                 columns=["a"],
                 base="a",
-                new_column_name="b",
             )
 
     def test_base_not_strictly_positive_error(self):
@@ -46,7 +46,6 @@ class TestInit(object):
             LogTransformer(
                 columns=["a"],
                 base=0,
-                new_column_name="b",
             )
 
     def test_class_methods(self):

--- a/tests/numeric/test_ScalingTransformer.py
+++ b/tests/numeric/test_ScalingTransformer.py
@@ -16,8 +16,9 @@ class TestInit(object):
 
         ta.functions.test_function_arguments(
             func=ScalingTransformer.__init__,
-            expected_arguments=["self", "columns", "scaler_type", "scaler_kwargs"],
-            expected_default_values=({},),
+            expected_arguments=["self", "columns", "scaler_type", "scaler_kwargs",
+                                "copy", "verbose"],
+            expected_default_values=(None, True, False),
         )
 
     def test_inheritance(self):

--- a/tests/strings/test_SeriesStrMethodTransformer.py
+++ b/tests/strings/test_SeriesStrMethodTransformer.py
@@ -21,8 +21,10 @@ class TestInit(object):
                 "pd_method_name",
                 "columns",
                 "pd_method_kwargs",
+                "copy",
+                "verbose"
             ],
-            expected_default_values=({},),
+            expected_default_values=(None, True, False),
         )
 
     def test_class_methods(self):

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -19,7 +19,7 @@ class TestInit(object):
         """List of transformers in tubular to be used in subsequent tests."""
 
         list_of_transformers = [
-            base.BaseTransformer(columns=["a"]),
+            base.BaseTransformer(columns=["a"], copy=True, verbose=False),
             base.DataFrameMethodTransformer(
                 new_column_name="a", pd_method_name="sum", columns="b"
             ),
@@ -41,15 +41,15 @@ class TestInit(object):
                 column_between="c",
                 new_column_name="c",
             ),
-            imputers.BaseImputer(),
+            imputers.BaseImputer(columns=None, copy=True, verbose=False),
             imputers.ArbitraryImputer(impute_value=1, columns="a"),
             imputers.MedianImputer(columns="a"),
             imputers.MeanImputer(columns="a"),
             imputers.ModeImputer(columns="a"),
-            imputers.NearestMeanResponseImputer(response_column="a"),
+            imputers.NearestMeanResponseImputer(columns="a"),
             imputers.NullIndicator(columns="a"),
             mapping.BaseMappingTransformer(mappings={"a": {1: 2, 3: 4}}),
-            mapping.BaseMappingTransformMixin(),
+            mapping.BaseMappingTransformMixin(columns=None, copy=True, verbose=False),
             mapping.MappingTransformer(mappings={"a": {1: 2, 3: 4}}),
             mapping.CrossColumnMappingTransformer(
                 adjust_column="b", mappings={"a": {1: 2, 3: 4}}
@@ -61,11 +61,11 @@ class TestInit(object):
                 adjust_column="b", mappings={"a": {1: 2, 3: 4}}
             ),
             misc.SetValueTransformer(columns="a", value=1),
-            nominal.BaseNominalTransformer(),
+            nominal.BaseNominalTransformer(columns=None, copy=True, verbose=False),
             nominal.NominalToIntegerTransformer(columns="a"),
             nominal.GroupRareLevelsTransformer(columns="a"),
-            nominal.MeanResponseTransformer(columns="a", response_column="b"),
-            nominal.OrdinalEncoderTransformer(columns="a", response_column="b"),
+            nominal.MeanResponseTransformer(columns="a"),
+            nominal.OrdinalEncoderTransformer(columns="a"),
             nominal.OneHotEncodingTransformer(columns="a"),
             numeric.LogTransformer(columns="a"),
             numeric.CutTransformer(column="a", new_column_name="b"),

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -13,7 +13,7 @@ from tubular._version import __version__
 
 
 class BaseTransformer(TransformerMixin, BaseEstimator):
-    """Base tranformer class which all other transformers in the package inherit from.
+    """Base transformer class which all other transformers in the package inherit from.
 
     Provides fit and transform methods (required by sklearn transformers), simple input checking
     and functionality to copy X prior to transform.
@@ -25,22 +25,19 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         in columns is saved in the columns attribute on the object.
 
     copy : bool, default = True
-        Should X be copied before tansforms are applied?
+        Should X be copied before transforms are applied?
 
     verbose : bool, default = False
         Should statements be printed when methods are run?
 
-    **kwds
-        Arbitrary keyword arguments.
-
     Attributes
     ----------
     columns : list or None
-        Either a list of str values giving which columns in a input pandas.DataFrame the transformer
+        Either a list of str values giving which columns in an input pandas.DataFrame the transformer
         will be applied to - or None.
 
     copy : bool
-        Should X be copied before tansforms are applied?
+        Should X be copied before transforms are applied?
 
     verbose : bool
         Print statements to show which methods are being run or not.
@@ -50,7 +47,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
     """
 
-    def __init__(self, columns=None, copy=True, verbose=False, **kwargs):
+    def __init__(self, columns=None, copy=True, verbose=False):
 
         self.version_ = __version__
 
@@ -189,9 +186,11 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         return X_y
 
     def transform(self, X):
-        """Base transformer transform method; checks X type (pandas DataFrame only) and copies data if requested.
+        """Base transformer transform method; checks X type (pandas DataFrame only)
+        and copies data if requested.
 
-        Transform calls the columns_check method which will check columns in columns attribute are in X.
+        Transform calls the columns_check method which will check columns in
+        columns attribute are in X.
 
         Parameters
         ----------
@@ -229,7 +228,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         Parameters
         ----------
-        attributes : List
+        attribute : List
             List of str values giving names of attribute to check exist on self.
 
         """
@@ -315,7 +314,7 @@ class ReturnKeyDict(dict):
 
 
 class DataFrameMethodTransformer(BaseTransformer):
-    """Tranformer that applies a pandas.DataFrame method.
+    """Transformer that applies a pandas.DataFrame method.
 
     Transformer assigns the output of the method to a new column or columns. It is possible to
     supply other key word arguments to the transform method, which will be passed to the
@@ -348,8 +347,11 @@ class DataFrameMethodTransformer(BaseTransformer):
     drop_original : bool, default = False
         Should original columns be dropped?
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.__init__().
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -367,12 +369,16 @@ class DataFrameMethodTransformer(BaseTransformer):
         new_column_name,
         pd_method_name,
         columns,
-        pd_method_kwargs={},
+        pd_method_kwargs=None,
         drop_original=False,
-        **kwargs,
+        copy=True,
+        verbose=False,
     ):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
+
+        if pd_method_kwargs is None:
+            pd_method_kwargs = dict()
 
         if type(new_column_name) is list:
 
@@ -435,10 +441,11 @@ class DataFrameMethodTransformer(BaseTransformer):
             ) from err
 
     def transform(self, X):
-        """Transform input pandas DataFrame (X) using the given pandas.DataFrame method and assign the output
-        back to column or columns in X.
+        """Transform input pandas DataFrame (X) using the given pandas.DataFrame
+        method and assign the output back to column or columns in X.
 
-        Any keyword arguments set in the pd_method_kwargs attribute are passed onto the pandas DataFrame method when calling it.
+        Any keyword arguments set in the pd_method_kwargs attribute are passed
+        onto the pandas DataFrame method when calling it.
 
         Parameters
         ----------
@@ -448,8 +455,8 @@ class DataFrameMethodTransformer(BaseTransformer):
         Returns
         -------
         X : pd.DataFrame
-            Input X with additional column or columns (self.new_column_name) added. These contain the output of
-            running the pandas DataFrame method.
+            Input X with additional column or columns (self.new_column_name) added.
+            These contain the output of running the pandas DataFrame method.
 
         """
 

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -64,7 +64,12 @@ class CappingTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, capping_values=None, quantiles=None, weights_column=None, copy=True, verbose=False
+        self,
+        capping_values=None,
+        quantiles=None,
+        weights_column=None,
+        copy=True,
+        verbose=False,
     ):
 
         if capping_values is None and quantiles is None:
@@ -86,7 +91,9 @@ class CappingTransformer(BaseTransformer):
 
             self.capping_values = capping_values
 
-            super().__init__(columns=list(capping_values.keys()), copy=copy, verbose=verbose)
+            super().__init__(
+                columns=list(capping_values.keys()), copy=copy, verbose=verbose
+            )
 
         if quantiles is not None:
 

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -5,7 +5,7 @@ This module contains a transformer that applies capping to numeric columns.
 import pandas as pd
 import numpy as np
 import warnings
-import copy
+from copy import deepcopy
 
 from tubular.base import BaseTransformer
 
@@ -40,8 +40,11 @@ class CappingTransformer(BaseTransformer):
         Optional weights column argument that can be used in combination with quantiles. Not used
         if capping_values is supplied. Allows weighted quantiles to be calculated.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -61,7 +64,7 @@ class CappingTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, capping_values=None, quantiles=None, weights_column=None, **kwargs
+        self, capping_values=None, quantiles=None, weights_column=None, copy=True, verbose=False
     ):
 
         if capping_values is None and quantiles is None:
@@ -83,7 +86,7 @@ class CappingTransformer(BaseTransformer):
 
             self.capping_values = capping_values
 
-            super().__init__(columns=list(capping_values.keys()), **kwargs)
+            super().__init__(columns=list(capping_values.keys()), copy=copy, verbose=verbose)
 
         if quantiles is not None:
 
@@ -103,11 +106,11 @@ class CappingTransformer(BaseTransformer):
 
             self.capping_values = {}
 
-            super().__init__(columns=list(quantiles.keys()), **kwargs)
+            super().__init__(columns=list(quantiles.keys()), copy=copy, verbose=verbose)
 
         self.quantiles = quantiles
         self.weights_column = weights_column
-        self._replacement_values = copy.deepcopy(self.capping_values)
+        self._replacement_values = deepcopy(self.capping_values)
 
     def check_capping_values_dict(self, capping_values_dict, dict_name):
         """Performs checks on a dictionary passed to ."""
@@ -205,7 +208,7 @@ class CappingTransformer(BaseTransformer):
 
             warnings.warn("quantiles not set so no fitting done in CappingTransformer")
 
-        self._replacement_values = copy.deepcopy(self.capping_values)
+        self._replacement_values = deepcopy(self.capping_values)
 
         return self
 

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -31,8 +31,11 @@ class DateDiffLeapYearTransformer(BaseTransformer):
         Value to output if either the lower date value or the upper date value are
         missing. Default value is None.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -62,7 +65,8 @@ class DateDiffLeapYearTransformer(BaseTransformer):
         new_column_name,
         drop_cols,
         missing_replacement=None,
-        **kwargs,
+        copy=True,
+        verbose=False,
     ):
 
         if not isinstance(column_lower, str):
@@ -83,7 +87,7 @@ class DateDiffLeapYearTransformer(BaseTransformer):
                     "if not None, missing_replacement should be an int, float or string"
                 )
 
-        super().__init__(columns=[column_lower, column_upper], **kwargs)
+        super().__init__(columns=[column_lower, column_upper], copy=copy, verbose=verbose)
 
         self.new_column_name = new_column_name
         self.drop_cols = drop_cols
@@ -289,12 +293,18 @@ class ToDatetimeTransformer(BaseTransformer):
     to_datetime_kwargs : dict, default = {}
         A dictionary of keyword arguments to be passed to the pd.to_datetime method when it is called in transform.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto pd.to_datetime().
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     """
 
-    def __init__(self, column, new_column_name, to_datetime_kwargs={}, **kwargs):
+    def __init__(self, column, new_column_name, to_datetime_kwargs=None, copy=True, verbose=False):
+
+        if to_datetime_kwargs is None:
+            to_datetime_kwargs = dict()
 
         if not type(column) is str:
 
@@ -329,7 +339,7 @@ class ToDatetimeTransformer(BaseTransformer):
         # Here only as a fix to allow string representation of transformer.
         self.column = column
 
-        super().__init__(columns=[column], **kwargs)
+        super().__init__(columns=[column], copy=copy, verbose=verbose)
 
     def transform(self, X):
         """Convert specified column to datetime using pd.to_datetime.
@@ -351,7 +361,7 @@ class ToDatetimeTransformer(BaseTransformer):
 
 
 class SeriesDtMethodTransformer(BaseTransformer):
-    """Tranformer that applies a pandas.Series.dt method.
+    """Transformer that applies a pandas.Series.dt method.
 
     Transformer assigns the output of the method to a new column. It is possible to
     supply other key word arguments to the transform method, which will be passed to the
@@ -402,17 +412,26 @@ class SeriesDtMethodTransformer(BaseTransformer):
     pd_method_kwargs : dict
         Dictionary of keyword arguments to call the pd.Series.dt method with.
 
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
+
     """
 
     def __init__(
-        self, new_column_name, pd_method_name, column, pd_method_kwargs={}, **kwargs
+        self, new_column_name, pd_method_name, column, pd_method_kwargs=None, copy=True, verbose=False
     ):
+
+        if pd_method_kwargs is None:
+            pd_method_kwargs = dict()
 
         if type(column) is not str:
 
             raise TypeError(f"column should be a str but got {type(column)}")
 
-        super().__init__(columns=column, **kwargs)
+        super().__init__(columns=column, copy=copy, verbose=verbose)
 
         if type(new_column_name) is not str:
 
@@ -526,16 +545,19 @@ class BetweenDatesTransformer(BaseTransformer):
     new_column_name : str
         Name for new column to be added to X.
 
-    lower_inclusive : bool, defualt = True
+    lower_inclusive : bool, default = True
         If lower_inclusive is True the comparison to column_lower will be column_lower <=
         column_between, otherwise the comparison will be column_lower < column_between.
 
-    upper_inclusive : bool, defualt = True
+    upper_inclusive : bool, default = True
         If upper_inclusive is True the comparison to column_upper will be column_between <=
         column_upper, otherwise the comparison will be column_between < column_upper.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.__init__().
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -574,7 +596,8 @@ class BetweenDatesTransformer(BaseTransformer):
         new_column_name,
         lower_inclusive=True,
         upper_inclusive=True,
-        **kwargs,
+        copy=True,
+        verbose=False
     ):
 
         if type(column_lower) is not str:
@@ -599,7 +622,8 @@ class BetweenDatesTransformer(BaseTransformer):
         self.lower_inclusive = lower_inclusive
         self.upper_inclusive = upper_inclusive
 
-        super().__init__(columns=[column_lower, column_between, column_upper], **kwargs)
+        super().__init__(columns=[column_lower, column_between, column_upper],
+                         copy=copy, verbose=verbose)
 
         # This attribute is not for use in any method, use 'columns' instead.
         # Here only as a fix to allow string representation of transformer.

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -87,7 +87,9 @@ class DateDiffLeapYearTransformer(BaseTransformer):
                     "if not None, missing_replacement should be an int, float or string"
                 )
 
-        super().__init__(columns=[column_lower, column_upper], copy=copy, verbose=verbose)
+        super().__init__(
+            columns=[column_lower, column_upper], copy=copy, verbose=verbose
+        )
 
         self.new_column_name = new_column_name
         self.drop_cols = drop_cols
@@ -301,7 +303,9 @@ class ToDatetimeTransformer(BaseTransformer):
 
     """
 
-    def __init__(self, column, new_column_name, to_datetime_kwargs=None, copy=True, verbose=False):
+    def __init__(
+        self, column, new_column_name, to_datetime_kwargs=None, copy=True, verbose=False
+    ):
 
         if to_datetime_kwargs is None:
             to_datetime_kwargs = dict()
@@ -421,7 +425,13 @@ class SeriesDtMethodTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, new_column_name, pd_method_name, column, pd_method_kwargs=None, copy=True, verbose=False
+        self,
+        new_column_name,
+        pd_method_name,
+        column,
+        pd_method_kwargs=None,
+        copy=True,
+        verbose=False,
     ):
 
         if pd_method_kwargs is None:
@@ -597,7 +607,7 @@ class BetweenDatesTransformer(BaseTransformer):
         lower_inclusive=True,
         upper_inclusive=True,
         copy=True,
-        verbose=False
+        verbose=False,
     ):
 
         if type(column_lower) is not str:
@@ -622,8 +632,11 @@ class BetweenDatesTransformer(BaseTransformer):
         self.lower_inclusive = lower_inclusive
         self.upper_inclusive = upper_inclusive
 
-        super().__init__(columns=[column_lower, column_between, column_upper],
-                         copy=copy, verbose=verbose)
+        super().__init__(
+            columns=[column_lower, column_between, column_upper],
+            copy=copy,
+            verbose=verbose,
+        )
 
         # This attribute is not for use in any method, use 'columns' instead.
         # Here only as a fix to allow string representation of transformer.

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -53,8 +53,11 @@ class ArbitraryImputer(BaseImputer):
         Columns to impute, if the default of None is supplied all columns in X are used
         when the transform method is called.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -63,13 +66,13 @@ class ArbitraryImputer(BaseImputer):
 
     """
 
-    def __init__(self, impute_value, columns, **kwargs):
+    def __init__(self, impute_value, columns, copy=True, verbose=False):
 
         if columns is None:
 
             raise ValueError("columns must be specified in init for ArbitraryImputer")
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
         if (
             not isinstance(impute_value, int)
@@ -129,8 +132,11 @@ class MedianImputer(BaseImputer):
         Columns to impute, if the default of None is supplied all columns in X are used
         when the transform method is called.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -140,9 +146,9 @@ class MedianImputer(BaseImputer):
 
     """
 
-    def __init__(self, columns=None, **kwargs):
+    def __init__(self, columns=None, copy=True, verbose=False):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def fit(self, X, y=None):
         """Calculate median values to impute with from X.
@@ -177,8 +183,11 @@ class MeanImputer(BaseImputer):
         Columns to impute, if the default of None is supplied all columns in X are used
         when the transform method is called.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -188,9 +197,9 @@ class MeanImputer(BaseImputer):
 
     """
 
-    def __init__(self, columns=None, **kwargs):
+    def __init__(self, columns=None, copy=True, verbose=False):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def fit(self, X, y=None):
         """Calculate mean values to impute with from X.
@@ -225,8 +234,11 @@ class ModeImputer(BaseImputer):
         Columns to impute, if the default of None is supplied all columns in X are used
         when the transform method is called.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -236,9 +248,9 @@ class ModeImputer(BaseImputer):
 
     """
 
-    def __init__(self, columns=None, **kwargs):
+    def __init__(self, columns=None, copy=True, verbose=False):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def fit(self, X, y=None):
         """Calculate mode values to impute with from X.
@@ -276,9 +288,9 @@ class NearestMeanResponseImputer(BaseImputer):
 
     """
 
-    def __init__(self, columns=None, **kwds):
+    def __init__(self, columns=None, copy=True, verbose=False):
 
-        super().__init__(columns=columns, **kwds)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def fit(self, X, y):
         """Calculate mean values to impute with.
@@ -349,11 +361,17 @@ class NullIndicator(BaseTransformer):
         Columns to produce indicator columns for, if the default of None is supplied all columns in X are used
         when the transform method is called.
 
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
+
     """
 
-    def __init__(self, columns=None, **kwds):
+    def __init__(self, columns=None, copy=True, verbose=False):
 
-        super().__init__(columns=columns, **kwds)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def transform(self, X):
         """Create new columns indicating the position of null values for each variable in self.columns.

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -20,8 +20,11 @@ class BaseMappingTransformer(BaseTransformer):
         example the following dict {'a': {1: 2, 3: 4}, 'b': {'a': 1, 'b': 2}} would specify
         a mapping for column a of 1->2, 3->4 and a mapping for column b of 'a'->1, b->2.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -31,7 +34,7 @@ class BaseMappingTransformer(BaseTransformer):
 
     """
 
-    def __init__(self, mappings, **kwargs):
+    def __init__(self, mappings, copy=True, verbose=False):
 
         if isinstance(mappings, dict):
 
@@ -55,7 +58,7 @@ class BaseMappingTransformer(BaseTransformer):
 
         columns = list(mappings.keys())
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def transform(self, X):
         """Base mapping transformer transform method.  Checks that the mappings

--- a/tubular/misc.py
+++ b/tubular/misc.py
@@ -14,16 +14,19 @@ class SetValueTransformer(BaseTransformer):
     value : various
         Value to set.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     """
 
-    def __init__(self, columns, value, **kwargs):
+    def __init__(self, columns, value, copy=True, verbose=False):
 
         self.value = value
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def transform(self, X):
         """Set columns to value.

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -89,8 +89,11 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
         {'A': 0, 'B': 1, 'C': 3} etc.. or if start_encoding = 5 then the same encoding would be
         {'A': 5, 'B': 6, 'C': 7}. Can be positive or negative.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -107,9 +110,9 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
 
     """
 
-    def __init__(self, columns=None, start_encoding=0, **kwargs):
+    def __init__(self, columns=None, start_encoding=0, copy=True, verbose=False):
 
-        BaseNominalTransformer.__init__(self, columns=columns, **kwargs)
+        BaseNominalTransformer.__init__(self, columns=columns, copy=copy, verbose=verbose)
 
         if not isinstance(start_encoding, int):
 
@@ -216,7 +219,7 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
     """Transformer to group together rare levels of nominal variables into a new level,
     labelled 'rare' (by default).
 
-    Rare levels are defined by a cut off percentage, which can either be based on the
+    Rare levels are defined by a cut-off percentage, which can either be based on the
     number of rows or sum of weights. Any levels below this cut off value will be
     grouped into the rare level.
 
@@ -244,8 +247,11 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
         Care should be taken if working with nominal variables with many levels as this could potentially
         result in many being stored in this attribute.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if should X be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -283,10 +289,11 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
         weight=None,
         rare_level_name="rare",
         record_rare_levels=True,
-        **kwargs,
+        copy=True,
+        verbose=False,
     ):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
         if not isinstance(cut_off_percent, float):
 
@@ -478,8 +485,11 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
     weights_column : str or None
         Weights column to use when calculating the mean response.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -492,7 +502,7 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
 
     """
 
-    def __init__(self, columns=None, weights_column=None, **kwargs):
+    def __init__(self, columns=None, weights_column=None, copy=True, verbose=False):
 
         if weights_column is not None:
 
@@ -502,7 +512,7 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
 
         self.weights_column = weights_column
 
-        BaseNominalTransformer.__init__(self, columns=columns, **kwargs)
+        BaseNominalTransformer.__init__(self, columns=columns, copy=copy, verbose=verbose)
 
     def fit(self, X, y):
         """Identify mapping of categorical levels to mean response values.
@@ -602,8 +612,11 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
     weights_column : str or None
         Weights column to use when calculating the mean response.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init method.
+    copy : bool
+        True if should X be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     Attributes
     ----------
@@ -616,7 +629,7 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
     """
 
-    def __init__(self, columns=None, weights_column=None, **kwargs):
+    def __init__(self, columns=None, weights_column=None, copy=True, verbose=False):
 
         if weights_column is not None:
 
@@ -626,7 +639,7 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
         self.weights_column = weights_column
 
-        BaseNominalTransformer.__init__(self, columns=columns, **kwargs)
+        BaseNominalTransformer.__init__(self, columns=columns, copy=copy, verbose=verbose)
 
     def fit(self, X, y):
         """Identify mapping of categorical levels to rank-ordered integer values by target-mean in ascending order.
@@ -760,7 +773,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
         Should warnings/checkmarks get displayed?
 
     **kwargs
-        Arbitrary keyword arguments passed onto sklearn OneHotEncoder.init method.
+        Keyword arguments to be passed to sklearn OneHotEncoder.init method.
 
     Attributes
     ----------
@@ -789,7 +802,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
         # Set attributes for scikit-learn'S OneHotEncoder
         OneHotEncoder.__init__(self, sparse=False, handle_unknown="ignore", **kwargs)
 
-        # Set other class attrributes
+        # Set other class attributes
         self.separator = separator
         self.drop_original = drop_original
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -112,7 +112,9 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
 
     def __init__(self, columns=None, start_encoding=0, copy=True, verbose=False):
 
-        BaseNominalTransformer.__init__(self, columns=columns, copy=copy, verbose=verbose)
+        BaseNominalTransformer.__init__(
+            self, columns=columns, copy=copy, verbose=verbose
+        )
 
         if not isinstance(start_encoding, int):
 
@@ -512,7 +514,9 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
 
         self.weights_column = weights_column
 
-        BaseNominalTransformer.__init__(self, columns=columns, copy=copy, verbose=verbose)
+        BaseNominalTransformer.__init__(
+            self, columns=columns, copy=copy, verbose=verbose
+        )
 
     def fit(self, X, y):
         """Identify mapping of categorical levels to mean response values.
@@ -639,7 +643,9 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
         self.weights_column = weights_column
 
-        BaseNominalTransformer.__init__(self, columns=columns, copy=copy, verbose=verbose)
+        BaseNominalTransformer.__init__(
+            self, columns=columns, copy=copy, verbose=verbose
+        )
 
     def fit(self, X, y):
         """Identify mapping of categorical levels to rank-ordered integer values by target-mean in ascending order.

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -57,8 +57,14 @@ class LogTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, columns, base=None, add_1=False, drop=True, suffix="log",
-            copy=True, verbose=False
+        self,
+        columns,
+        base=None,
+        add_1=False,
+        drop=True,
+        suffix="log",
+        copy=True,
+        verbose=False,
     ):
 
         super().__init__(columns=columns, copy=copy, verbose=verbose)
@@ -175,7 +181,9 @@ class CutTransformer(BaseTransformer):
 
     """
 
-    def __init__(self, column, new_column_name, cut_kwargs=None, copy=True, verbose=False):
+    def __init__(
+        self, column, new_column_name, cut_kwargs=None, copy=True, verbose=False
+    ):
 
         if cut_kwargs is None:
             cut_kwargs = dict()
@@ -264,7 +272,9 @@ class ScalingTransformer(BaseTransformer):
 
     """
 
-    def __init__(self, columns, scaler_type, scaler_kwargs=None, copy=True, verbose=False):
+    def __init__(
+        self, columns, scaler_type, scaler_kwargs=None, copy=True, verbose=False
+    ):
 
         if scaler_kwargs is None:
             scaler_kwargs = dict()

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -57,10 +57,11 @@ class LogTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, columns, base=None, add_1=False, drop=True, suffix="log", **kwargs
+        self, columns, base=None, add_1=False, drop=True, suffix="log",
+            copy=True, verbose=False
     ):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
         if base is not None:
             if not isinstance(base, (int, float)):
@@ -166,12 +167,18 @@ class CutTransformer(BaseTransformer):
     cut_kwargs : dict, default = {}
         A dictionary of keyword arguments to be passed to the pd.cut method when it is called in transform.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init().
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     """
 
-    def __init__(self, column, new_column_name, cut_kwargs={}, **kwargs):
+    def __init__(self, column, new_column_name, cut_kwargs=None, copy=True, verbose=False):
+
+        if cut_kwargs is None:
+            cut_kwargs = dict()
 
         if not type(column) is str:
 
@@ -206,7 +213,7 @@ class CutTransformer(BaseTransformer):
         # Here only as a fix to allow string representation of transformer.
         self.column = column
 
-        super().__init__(columns=[column], **kwargs)
+        super().__init__(columns=[column], copy=copy, verbose=verbose)
 
     def transform(self, X):
         """Discretise specified column using pd.cut.
@@ -249,12 +256,18 @@ class ScalingTransformer(BaseTransformer):
     scaler_kwargs : dict, default = {}
         A dictionary of keyword arguments to be passed to the scaler object when it is initialised.
 
-    **kwargs
-        Arbitrary keyword arguments passed onto BaseTransformer.init().
+    copy : bool
+        True if X should be copied before transforms are applied, False otherwise
+
+    verbose : bool
+        True to print statements to show which methods are being run or not.
 
     """
 
-    def __init__(self, columns, scaler_type, scaler_kwargs={}, **kwargs):
+    def __init__(self, columns, scaler_type, scaler_kwargs=None, copy=True, verbose=False):
+
+        if scaler_kwargs is None:
+            scaler_kwargs = dict()
 
         if not type(scaler_kwargs) is dict:
 
@@ -295,7 +308,7 @@ class ScalingTransformer(BaseTransformer):
         self.scaler_kwargs = scaler_kwargs
         self.scaler_type = scaler_type
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
     def check_numeric_columns(self, X):
         """Method to check all columns (specicifed in self.columns) in X are all numeric.
@@ -393,6 +406,12 @@ class InteractionTransformer(BaseTransformer):
         max_degree : int
             maximum degree of interaction features to be considered. For example if max_degree=3, only interaction
             columns from up to 3 columns would be generated.
+        copy : bool
+            True if X should be copied before transforms are applied, False otherwise
+
+        verbose : bool
+            True to print statements to show which methods are being run or not.
+
 
 
          Attributes
@@ -413,9 +432,9 @@ class InteractionTransformer(BaseTransformer):
 
     """
 
-    def __init__(self, columns, min_degree=2, max_degree=2, **kwargs):
+    def __init__(self, columns, min_degree=2, max_degree=2, copy=True, verbose=False):
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
         if len(columns) < 2:
             raise ValueError(

--- a/tubular/strings.py
+++ b/tubular/strings.py
@@ -8,7 +8,7 @@ from tubular.base import BaseTransformer
 
 
 class SeriesStrMethodTransformer(BaseTransformer):
-    """Tranformer that applies a pandas.Series.str method.
+    """Transformer that applies a pandas.Series.str method.
 
     Transformer assigns the output of the method to a new column. It is possible to
     supply other key word arguments to the transform method, which will be passed to the
@@ -52,8 +52,11 @@ class SeriesStrMethodTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, new_column_name, pd_method_name, columns, pd_method_kwargs={}, **kwargs
+        self, new_column_name, pd_method_name, columns, pd_method_kwargs=None,
+            copy=True, verbose=False
     ):
+        if pd_method_kwargs is None:
+            pd_method_kwargs = dict()
 
         if type(columns) is list:
 
@@ -63,7 +66,7 @@ class SeriesStrMethodTransformer(BaseTransformer):
                     f"columns arg should contain only 1 column name but got {len(columns)}"
                 )
 
-        super().__init__(columns=columns, **kwargs)
+        super().__init__(columns=columns, copy=copy, verbose=verbose)
 
         if type(new_column_name) is not str:
 

--- a/tubular/strings.py
+++ b/tubular/strings.py
@@ -52,8 +52,13 @@ class SeriesStrMethodTransformer(BaseTransformer):
     """
 
     def __init__(
-        self, new_column_name, pd_method_name, columns, pd_method_kwargs=None,
-            copy=True, verbose=False
+        self,
+        new_column_name,
+        pd_method_name,
+        columns,
+        pd_method_kwargs=None,
+        copy=True,
+        verbose=False,
     ):
         if pd_method_kwargs is None:
             pd_method_kwargs = dict()


### PR DESCRIPTION
Fixes issue #43 where 'base.BaseTransformer' was accepting kwargs even when its parent classes did not expect any. This was propagating as a bug where any unexpected/wrong argument passed to child classes did not raise any error.

There were some unit tests that where failing because of old used arguments that went silently and one that even had a wrong argument passed to.

Some notes on the PR:

* By executing black I had an issue and had to update to black==22.3.0.  Since the contributions guide says that there should be one feature per PR
* I did not fix any version in the Changelog, since I'm not sure when you plan to make a release and also because of the previous point.
* There were few places when lists and dictionaries where defined as default parameters in the __init__ functions, so I changed them for None and and changing to the original one in the code. That might generate problems with mutation in some cases.

Overall it was fun to solve, but a bit too long. A recommendation would be to remove the possibility to have the arguments 'columns', 'copy' and 'verbose' from the 'BaseTransformer', but that is just taste/design choice and not a bug or issue.