### PR TITLE
prefix errors with transformer classname

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ Each individual change should have a link to the pull request after the descript
 0.3.3 (Unreleased)
 ------------------
 
+Added
+^^^^^
+- added classname() method to BaseTransformer and prefixed all errors with classname call for easier debugging `#48 <https://github.com/lvgig/tubular/pull/48>`_
+
 Fixed
 ^^^^^
 - updated black version to 22.3.0 and flake8 version to 5.0.4 to fix compatibility issues `#45 <https://github.com/lvgig/tubular/pull/45>`_

--- a/tests/base/test_BaseTransformer.py
+++ b/tests/base/test_BaseTransformer.py
@@ -162,7 +162,9 @@ class TestFit(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
+        with pytest.raises(
+            TypeError, match="BaseTransformer: X should be a pd.DataFrame"
+        ):
 
             x.fit("a")
 
@@ -174,7 +176,8 @@ class TestFit(object):
         x = BaseTransformer(columns="a")
 
         with pytest.raises(
-            TypeError, match="BaseTransformer: unexpected type for y, should be a pd.Series"
+            TypeError,
+            match="BaseTransformer: unexpected type for y, should be a pd.Series",
         ):
 
             x.fit(X=df, y=[1, 2, 3, 4, 5, 6])
@@ -204,7 +207,9 @@ class TestFit(object):
 
         df = pandas.DataFrame(columns=["a"])
 
-        with pytest.raises(ValueError, match=re.escape("BaseTransformer: X has no rows; (0, 1)")):
+        with pytest.raises(
+            ValueError, match=re.escape("BaseTransformer: X has no rows; (0, 1)")
+        ):
 
             x.fit(X=df)
 
@@ -215,7 +220,9 @@ class TestFit(object):
 
         df = pandas.DataFrame({"a": 1}, index=[0])
 
-        with pytest.raises(ValueError, match=re.escape("BaseTransformer: y is empty; (0,)")):
+        with pytest.raises(
+            ValueError, match=re.escape("BaseTransformer: y is empty; (0,)")
+        ):
 
             x.fit(X=df, y=pandas.Series(name="b", dtype=object))
 
@@ -250,7 +257,9 @@ class TestTransform(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
+        with pytest.raises(
+            TypeError, match="BaseTransformer: X should be a pd.DataFrame"
+        ):
 
             x.transform(X=[1, 2, 3, 4, 5, 6])
 
@@ -276,7 +285,9 @@ class TestTransform(object):
 
         df = pandas.DataFrame(columns=["a"])
 
-        with pytest.raises(ValueError, match=re.escape("BaseTransformer:X has no rows; (0, 1)")):
+        with pytest.raises(
+            ValueError, match=re.escape("BaseTransformer:X has no rows; (0, 1)")
+        ):
 
             x.transform(df)
 
@@ -313,7 +324,9 @@ class TestColumnsCheck(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
+        with pytest.raises(
+            TypeError, match="BaseTransformer: X should be a pd.DataFrame"
+        ):
 
             x.columns_check(X=[1, 2, 3, 4, 5, 6])
 
@@ -339,7 +352,9 @@ class TestColumnsCheck(object):
 
         x.columns = "a"
 
-        with pytest.raises(TypeError, match="BaseTransformer: self.columns should be a list"):
+        with pytest.raises(
+            TypeError, match="BaseTransformer: self.columns should be a list"
+        ):
 
             x.columns_check(X=df)
 
@@ -370,7 +385,9 @@ class TestColumnsSetOrCheck(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
+        with pytest.raises(
+            TypeError, match="BaseTransformer: X should be a pd.DataFrame"
+        ):
 
             x.columns_set_or_check(X=[1, 2, 3, 4, 5, 6])
 
@@ -446,7 +463,9 @@ class TestCombineXy:
 
         x = BaseTransformer(columns=["a"])
 
-        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
+        with pytest.raises(
+            TypeError, match="BaseTransformer: X should be a pd.DataFrame"
+        ):
 
             x._combine_X_y(X=1, y=pandas.Series([1, 2]))
 
@@ -466,7 +485,9 @@ class TestCombineXy:
 
         with pytest.raises(
             ValueError,
-            match=re.escape("BaseTransformer: X and y have different numbers of rows (2 vs 1)"),
+            match=re.escape(
+                "BaseTransformer: X and y have different numbers of rows (2 vs 1)"
+            ),
         ):
 
             x._combine_X_y(X=pandas.DataFrame({"a": [1, 2]}), y=pandas.Series([2]))
@@ -476,7 +497,9 @@ class TestCombineXy:
 
         x = BaseTransformer(columns=["a"])
 
-        with pytest.warns(UserWarning, match="BaseTransformer: X and y do not have equal indexes"):
+        with pytest.warns(
+            UserWarning, match="BaseTransformer: X and y do not have equal indexes"
+        ):
 
             result = x._combine_X_y(
                 X=pandas.DataFrame({"a": [1, 2]}, index=[1, 2]), y=pandas.Series([2, 4])

--- a/tests/base/test_BaseTransformer.py
+++ b/tests/base/test_BaseTransformer.py
@@ -286,7 +286,7 @@ class TestTransform(object):
         df = pandas.DataFrame(columns=["a"])
 
         with pytest.raises(
-            ValueError, match=re.escape("BaseTransformer:X has no rows; (0, 1)")
+            ValueError, match=re.escape("BaseTransformer: X has no rows; (0, 1)")
         ):
 
             x.transform(df)

--- a/tests/base/test_BaseTransformer.py
+++ b/tests/base/test_BaseTransformer.py
@@ -91,14 +91,14 @@ class TestInit(object):
     def test_verbose_non_bool_error(self):
         """Test an error is raised if verbose is not specified as a bool."""
 
-        with pytest.raises(TypeError, match="verbose must be a bool"):
+        with pytest.raises(TypeError, match="BaseTransformer: verbose must be a bool"):
 
             BaseTransformer(verbose=1)
 
     def test_copy_non_bool_error(self):
         """Test an error is raised if copy is not specified as a bool."""
 
-        with pytest.raises(TypeError, match="copy must be a bool"):
+        with pytest.raises(TypeError, match="BaseTransformer: copy must be a bool"):
 
             BaseTransformer(copy=1)
 
@@ -115,7 +115,7 @@ class TestInit(object):
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "each element of columns should be a single (string) column name"
+                "BaseTransformer: each element of columns should be a single (string) column name"
             ),
         ):
 
@@ -127,7 +127,7 @@ class TestInit(object):
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "columns must be a string or list with the columns to be pre-processed (if specified)"
+                "BaseTransformer: columns must be a string or list with the columns to be pre-processed (if specified)"
             ),
         ):
 
@@ -162,7 +162,7 @@ class TestFit(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
+        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
 
             x.fit("a")
 
@@ -174,7 +174,7 @@ class TestFit(object):
         x = BaseTransformer(columns="a")
 
         with pytest.raises(
-            TypeError, match="unexpected type for y, should be a pd.Series"
+            TypeError, match="BaseTransformer: unexpected type for y, should be a pd.Series"
         ):
 
             x.fit(X=df, y=[1, 2, 3, 4, 5, 6])
@@ -204,7 +204,7 @@ class TestFit(object):
 
         df = pandas.DataFrame(columns=["a"])
 
-        with pytest.raises(ValueError, match=re.escape("X has no rows; (0, 1)")):
+        with pytest.raises(ValueError, match=re.escape("BaseTransformer: X has no rows; (0, 1)")):
 
             x.fit(X=df)
 
@@ -215,7 +215,7 @@ class TestFit(object):
 
         df = pandas.DataFrame({"a": 1}, index=[0])
 
-        with pytest.raises(ValueError, match=re.escape("y is empty; (0,)")):
+        with pytest.raises(ValueError, match=re.escape("BaseTransformer: y is empty; (0,)")):
 
             x.fit(X=df, y=pandas.Series(name="b", dtype=object))
 
@@ -250,7 +250,7 @@ class TestTransform(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
+        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
 
             x.transform(X=[1, 2, 3, 4, 5, 6])
 
@@ -276,7 +276,7 @@ class TestTransform(object):
 
         df = pandas.DataFrame(columns=["a"])
 
-        with pytest.raises(ValueError, match=re.escape("X has no rows; (0, 1)")):
+        with pytest.raises(ValueError, match=re.escape("BaseTransformer:X has no rows; (0, 1)")):
 
             x.transform(df)
 
@@ -313,7 +313,7 @@ class TestColumnsCheck(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
+        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
 
             x.columns_check(X=[1, 2, 3, 4, 5, 6])
 
@@ -339,7 +339,7 @@ class TestColumnsCheck(object):
 
         x.columns = "a"
 
-        with pytest.raises(TypeError, match="self.columns should be a list"):
+        with pytest.raises(TypeError, match="BaseTransformer: self.columns should be a list"):
 
             x.columns_check(X=df)
 
@@ -370,7 +370,7 @@ class TestColumnsSetOrCheck(object):
 
         x = BaseTransformer(columns="a")
 
-        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
+        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
 
             x.columns_set_or_check(X=[1, 2, 3, 4, 5, 6])
 
@@ -446,7 +446,7 @@ class TestCombineXy:
 
         x = BaseTransformer(columns=["a"])
 
-        with pytest.raises(TypeError, match="X should be a pd.DataFrame"):
+        with pytest.raises(TypeError, match="BaseTransformer: X should be a pd.DataFrame"):
 
             x._combine_X_y(X=1, y=pandas.Series([1, 2]))
 
@@ -455,7 +455,7 @@ class TestCombineXy:
 
         x = BaseTransformer(columns=["a"])
 
-        with pytest.raises(TypeError, match="y should be a pd.Series"):
+        with pytest.raises(TypeError, match="BaseTransformer: y should be a pd.Series"):
 
             x._combine_X_y(X=pandas.DataFrame({"a": [1, 2]}), y=1)
 
@@ -466,7 +466,7 @@ class TestCombineXy:
 
         with pytest.raises(
             ValueError,
-            match=re.escape("X and y have different numbers of rows (2 vs 1)"),
+            match=re.escape("BaseTransformer: X and y have different numbers of rows (2 vs 1)"),
         ):
 
             x._combine_X_y(X=pandas.DataFrame({"a": [1, 2]}), y=pandas.Series([2]))
@@ -476,7 +476,7 @@ class TestCombineXy:
 
         x = BaseTransformer(columns=["a"])
 
-        with pytest.warns(UserWarning, match="X and y do not have equal indexes"):
+        with pytest.warns(UserWarning, match="BaseTransformer: X and y do not have equal indexes"):
 
             result = x._combine_X_y(
                 X=pandas.DataFrame({"a": [1, 2]}, index=[1, 2]), y=pandas.Series([2, 4])

--- a/tests/base/test_DataFrameMethodTransformer.py
+++ b/tests/base/test_DataFrameMethodTransformer.py
@@ -74,7 +74,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'int'\>\) for pd_method_name, expecting str",
+            match=r"DataFrameMethodTransformer: unexpected type \(\<class 'int'\>\) for pd_method_name, expecting str",
         ):
 
             DataFrameMethodTransformer(
@@ -83,7 +83,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'float'\>\) for new_column_name, must be str or list of strings",
+            match=r"DataFrameMethodTransformer: unexpected type \(\<class 'float'\>\) for new_column_name, must be str or list of strings",
         ):
 
             DataFrameMethodTransformer(
@@ -92,7 +92,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"if new_column_name is a list, all elements must be strings but got \<class 'float'\> in position 1",
+            match=r"DataFrameMethodTransformer: if new_column_name is a list, all elements must be strings but got \<class 'float'\> in position 1",
         ):
 
             DataFrameMethodTransformer(
@@ -101,7 +101,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""pd_method_kwargs should be a dict but got type \<class 'int'\>""",
+            match=r"""DataFrameMethodTransformer: pd_method_kwargs should be a dict but got type \<class 'int'\>""",
         ):
 
             DataFrameMethodTransformer(
@@ -113,7 +113,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'int'\>\) for pd_method_kwargs key in position 1, must be str""",
+            match=r"""DataFrameMethodTransformer: unexpected type \(\<class 'int'\>\) for pd_method_kwargs key in position 1, must be str""",
         ):
 
             DataFrameMethodTransformer(
@@ -125,7 +125,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'int'\>\) for drop_original, expecting bool",
+            match=r"DataFrameMethodTransformer: unexpected type \(\<class 'int'\>\) for drop_original, expecting bool",
         ):
 
             DataFrameMethodTransformer(
@@ -140,7 +140,7 @@ class TestInit(object):
 
         with pytest.raises(
             AttributeError,
-            match="""error accessing "b" method on pd.DataFrame object - pd_method_name should be a pd.DataFrame method""",
+            match="""DataFrameMethodTransformer: error accessing "b" method on pd.DataFrame object - pd_method_name should be a pd.DataFrame method""",
         ):
 
             DataFrameMethodTransformer(

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -314,7 +314,9 @@ class TestCheckCappingValuesDict(object):
 
         x = CappingTransformer(capping_values={"a": [1, 3], "b": [None, -1]})
 
-        with pytest.raises(ValueError, match="CappingTransformer: both values are None for key a"):
+        with pytest.raises(
+            ValueError, match="CappingTransformer: both values are None for key a"
+        ):
 
             x.check_capping_values_dict(
                 capping_values_dict={"a": [None, None], "b": [None, 1]}, dict_name="eee"
@@ -745,7 +747,8 @@ class TestTransform(object):
         x = CappingTransformer(capping_values={"a": [2, 5], "b": [-1, 8], "c": [-1, 8]})
 
         with pytest.raises(
-            TypeError, match=r"CappingTransformer: The following columns are not numeric in X; \['b', 'c'\]"
+            TypeError,
+            match=r"CappingTransformer: The following columns are not numeric in X; \['b', 'c'\]",
         ):
 
             x.transform(df)
@@ -874,7 +877,8 @@ class TestWeightedQuantile(object):
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
         with pytest.raises(
-            ValueError, match="CappingTransformer: total sample weights are not greater than 0"
+            ValueError,
+            match="CappingTransformer: total sample weights are not greater than 0",
         ):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [0, 0])
@@ -884,7 +888,9 @@ class TestWeightedQuantile(object):
 
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
-        with pytest.raises(ValueError, match="CappingTransformer: null values in sample weights"):
+        with pytest.raises(
+            ValueError, match="CappingTransformer: null values in sample weights"
+        ):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [3, np.NaN])
 
@@ -893,11 +899,15 @@ class TestWeightedQuantile(object):
 
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
-        with pytest.raises(ValueError, match="CappingTransformer: infinite values in sample weights"):
+        with pytest.raises(
+            ValueError, match="CappingTransformer: infinite values in sample weights"
+        ):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [2, np.inf])
 
-        with pytest.raises(ValueError, match="CappingTransformer: infinite values in sample weights"):
+        with pytest.raises(
+            ValueError, match="CappingTransformer: infinite values in sample weights"
+        ):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [1, -np.inf])
 
@@ -906,6 +916,8 @@ class TestWeightedQuantile(object):
 
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
-        with pytest.raises(ValueError, match="CappingTransformer: negative weights in sample weights"):
+        with pytest.raises(
+            ValueError, match="CappingTransformer: negative weights in sample weights"
+        ):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [2, -0.01])

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -56,7 +56,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match="both capping_values and quantiles are None, either supply capping values in the "
+            match="CappingTransformer: both capping_values and quantiles are None, either supply capping values in the "
             "capping_values argument or supply quantiles that can be learnt in the fit method",
         ):
 
@@ -67,7 +67,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match="both capping_values and quantiles are not None, supply one or the other",
+            match="CappingTransformer: both capping_values and quantiles are not None, supply one or the other",
         ):
 
             CappingTransformer(
@@ -80,7 +80,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=rf"quantile values must be in the range \[0, 1\] but got {out_range_value} for key f",
+            match=rf"CappingTransformer: quantile values must be in the range \[0, 1\] but got {out_range_value} for key f",
         ):
 
             CappingTransformer(
@@ -217,7 +217,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             TypeError,
-            match="aaa should be dict of columns and capping values",
+            match="CappingTransformer: aaa should be dict of columns and capping values",
         ):
 
             x.check_capping_values_dict(
@@ -231,7 +231,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             TypeError,
-            match=r"all keys in bbb should be str, but got \<class 'int'\>",
+            match=r"CappingTransformer: all keys in bbb should be str, but got \<class 'int'\>",
         ):
 
             x.check_capping_values_dict(
@@ -245,7 +245,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             TypeError,
-            match=r"each item in ccc should be a list, but got \<class 'tuple'\> for key b",
+            match=r"CappingTransformer: each item in ccc should be a list, but got \<class 'tuple'\> for key b",
         ):
 
             x.check_capping_values_dict(
@@ -259,7 +259,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             ValueError,
-            match="each item in ddd should be length 2, but got 1 for key b",
+            match="CappingTransformer: each item in ddd should be length 2, but got 1 for key b",
         ):
 
             x.check_capping_values_dict(
@@ -273,7 +273,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             TypeError,
-            match=r"each item in eee lists must contain numeric values or None, got \<class 'str'\> for key a",
+            match=r"CappingTransformer: each item in eee lists must contain numeric values or None, got \<class 'str'\> for key a",
         ):
 
             x.check_capping_values_dict(
@@ -287,7 +287,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             ValueError,
-            match="lower value is greater than or equal to upper value for key a",
+            match="CappingTransformer: lower value is greater than or equal to upper value for key a",
         ):
 
             x.check_capping_values_dict(
@@ -302,7 +302,7 @@ class TestCheckCappingValuesDict(object):
 
         with pytest.raises(
             ValueError,
-            match="item in eee lists contains numpy NaN or Inf values",
+            match="CappingTransformer: item in eee lists contains numpy NaN or Inf values",
         ):
 
             x.check_capping_values_dict(
@@ -314,7 +314,7 @@ class TestCheckCappingValuesDict(object):
 
         x = CappingTransformer(capping_values={"a": [1, 3], "b": [None, -1]})
 
-        with pytest.raises(ValueError, match="both values are None for key a"):
+        with pytest.raises(ValueError, match="CappingTransformer: both values are None for key a"):
 
             x.check_capping_values_dict(
                 capping_values_dict={"a": [None, None], "b": [None, 1]}, dict_name="eee"
@@ -338,7 +338,7 @@ class TestFit(object):
 
         with pytest.warns(
             UserWarning,
-            match="quantiles not set so no fitting done in CappingTransformer",
+            match="CappingTransformer: quantiles not set so no fitting done in CappingTransformer",
         ):
 
             df = d.create_df_3()
@@ -745,7 +745,7 @@ class TestTransform(object):
         x = CappingTransformer(capping_values={"a": [2, 5], "b": [-1, 8], "c": [-1, 8]})
 
         with pytest.raises(
-            TypeError, match=r"The following columns are not numeric in X; \['b', 'c'\]"
+            TypeError, match=r"CappingTransformer: The following columns are not numeric in X; \['b', 'c'\]"
         ):
 
             x.transform(df)
@@ -759,7 +759,7 @@ class TestTransform(object):
 
         with pytest.raises(
             ValueError,
-            match="capping_values attribute is an empty dict - perhaps the fit method has not been run yet",
+            match="CappingTransformer: capping_values attribute is an empty dict - perhaps the fit method has not been run yet",
         ):
 
             x.transform(df)
@@ -776,7 +776,7 @@ class TestTransform(object):
 
         with pytest.raises(
             ValueError,
-            match="_replacement_values attribute is an empty dict - perhaps the fit method has not been run yet",
+            match="CappingTransformer: _replacement_values attribute is an empty dict - perhaps the fit method has not been run yet",
         ):
 
             x.transform(df)
@@ -874,7 +874,7 @@ class TestWeightedQuantile(object):
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
         with pytest.raises(
-            ValueError, match="total sample weights are not greater than 0"
+            ValueError, match="CappingTransformer: total sample weights are not greater than 0"
         ):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [0, 0])
@@ -884,7 +884,7 @@ class TestWeightedQuantile(object):
 
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
-        with pytest.raises(ValueError, match="null values in sample weights"):
+        with pytest.raises(ValueError, match="CappingTransformer: null values in sample weights"):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [3, np.NaN])
 
@@ -893,11 +893,11 @@ class TestWeightedQuantile(object):
 
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
-        with pytest.raises(ValueError, match="infinite values in sample weights"):
+        with pytest.raises(ValueError, match="CappingTransformer: infinite values in sample weights"):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [2, np.inf])
 
-        with pytest.raises(ValueError, match="infinite values in sample weights"):
+        with pytest.raises(ValueError, match="CappingTransformer: infinite values in sample weights"):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [1, -np.inf])
 
@@ -906,6 +906,6 @@ class TestWeightedQuantile(object):
 
         x = CappingTransformer(capping_values={"a": [2, 10]})
 
-        with pytest.raises(ValueError, match="negative weights in sample weights"):
+        with pytest.raises(ValueError, match="CappingTransformer: negative weights in sample weights"):
 
             x.weighted_quantile([2, 3, 4, 5], [0, 1], [2, -0.01])

--- a/tests/dates/test_BetweenDatesTransformer.py
+++ b/tests/dates/test_BetweenDatesTransformer.py
@@ -64,7 +64,9 @@ class TestInit(object):
     def test_first_non_str_error(self):
         """Test that an exception is raised if column_lower not str."""
 
-        with pytest.raises(TypeError, match="BetweenDatesTransformer: column_lower should be str"):
+        with pytest.raises(
+            TypeError, match="BetweenDatesTransformer: column_lower should be str"
+        ):
 
             BetweenDatesTransformer(
                 column_lower=False,
@@ -76,7 +78,9 @@ class TestInit(object):
     def test_column_between_non_str_error(self):
         """Test that an exception is raised if column_between not str."""
 
-        with pytest.raises(TypeError, match="BetweenDatesTransformer: column_between should be str"):
+        with pytest.raises(
+            TypeError, match="BetweenDatesTransformer: column_between should be str"
+        ):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -88,7 +92,9 @@ class TestInit(object):
     def test_column_upper_non_str_error(self):
         """Test that an exception is raised if column_upper not str."""
 
-        with pytest.raises(TypeError, match="BetweenDatesTransformer: column_upper should be str"):
+        with pytest.raises(
+            TypeError, match="BetweenDatesTransformer: column_upper should be str"
+        ):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -100,7 +106,9 @@ class TestInit(object):
     def test_new_column_name_non_str_error(self):
         """Test that an exception is raised if new_column_name not str."""
 
-        with pytest.raises(TypeError, match="BetweenDatesTransformer: new_column_name should be str"):
+        with pytest.raises(
+            TypeError, match="BetweenDatesTransformer: new_column_name should be str"
+        ):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -112,7 +120,9 @@ class TestInit(object):
     def test_lower_inclusive_non_bool_error(self):
         """Test that an exception is raised if lower_inclusive not a bool."""
 
-        with pytest.raises(TypeError, match="BetweenDatesTransformer: lower_inclusive should be a bool"):
+        with pytest.raises(
+            TypeError, match="BetweenDatesTransformer: lower_inclusive should be a bool"
+        ):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -125,7 +135,9 @@ class TestInit(object):
     def test_upper_inclusive_non_bool_error(self):
         """Test that an exception is raised if upper_inclusive not a bool."""
 
-        with pytest.raises(TypeError, match="BetweenDatesTransformer: upper_inclusive should be a bool"):
+        with pytest.raises(
+            TypeError, match="BetweenDatesTransformer: upper_inclusive should be a bool"
+        ):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -269,7 +281,8 @@ class TestTransform(object):
         )
 
         with pytest.raises(
-            TypeError, match=r"BetweenDatesTransformer: a should be datetime64\[ns\] type but got int64"
+            TypeError,
+            match=r"BetweenDatesTransformer: a should be datetime64\[ns\] type but got int64",
         ):
 
             x.transform(df)

--- a/tests/dates/test_BetweenDatesTransformer.py
+++ b/tests/dates/test_BetweenDatesTransformer.py
@@ -64,7 +64,7 @@ class TestInit(object):
     def test_first_non_str_error(self):
         """Test that an exception is raised if column_lower not str."""
 
-        with pytest.raises(TypeError, match="column_lower should be str"):
+        with pytest.raises(TypeError, match="BetweenDatesTransformer: column_lower should be str"):
 
             BetweenDatesTransformer(
                 column_lower=False,
@@ -76,7 +76,7 @@ class TestInit(object):
     def test_column_between_non_str_error(self):
         """Test that an exception is raised if column_between not str."""
 
-        with pytest.raises(TypeError, match="column_between should be str"):
+        with pytest.raises(TypeError, match="BetweenDatesTransformer: column_between should be str"):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -88,7 +88,7 @@ class TestInit(object):
     def test_column_upper_non_str_error(self):
         """Test that an exception is raised if column_upper not str."""
 
-        with pytest.raises(TypeError, match="column_upper should be str"):
+        with pytest.raises(TypeError, match="BetweenDatesTransformer: column_upper should be str"):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -100,7 +100,7 @@ class TestInit(object):
     def test_new_column_name_non_str_error(self):
         """Test that an exception is raised if new_column_name not str."""
 
-        with pytest.raises(TypeError, match="new_column_name should be str"):
+        with pytest.raises(TypeError, match="BetweenDatesTransformer: new_column_name should be str"):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -112,7 +112,7 @@ class TestInit(object):
     def test_lower_inclusive_non_bool_error(self):
         """Test that an exception is raised if lower_inclusive not a bool."""
 
-        with pytest.raises(TypeError, match="lower_inclusive should be a bool"):
+        with pytest.raises(TypeError, match="BetweenDatesTransformer: lower_inclusive should be a bool"):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -125,7 +125,7 @@ class TestInit(object):
     def test_upper_inclusive_non_bool_error(self):
         """Test that an exception is raised if upper_inclusive not a bool."""
 
-        with pytest.raises(TypeError, match="upper_inclusive should be a bool"):
+        with pytest.raises(TypeError, match="BetweenDatesTransformer: upper_inclusive should be a bool"):
 
             BetweenDatesTransformer(
                 column_lower="a",
@@ -269,7 +269,7 @@ class TestTransform(object):
         )
 
         with pytest.raises(
-            TypeError, match=r"a should be datetime64\[ns\] type but got int64"
+            TypeError, match=r"BetweenDatesTransformer: a should be datetime64\[ns\] type but got int64"
         ):
 
             x.transform(df)

--- a/tests/dates/test_DateDiffLeapYearTransformer.py
+++ b/tests/dates/test_DateDiffLeapYearTransformer.py
@@ -20,7 +20,9 @@ class TestCalculateAge(object):
             column_lower="a", column_upper="b", new_column_name="c", drop_cols=True
         )
 
-        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: row should be a pd.Series"):
+        with pytest.raises(
+            TypeError, match="DateDiffLeapYearTransformer: row should be a pd.Series"
+        ):
 
             date_transformer.calculate_age(row=row)
 
@@ -149,7 +151,9 @@ class TestInit(object):
     def test_column_lower_type_error(self):
         """Test that an exception is raised if column_lower is not a str."""
 
-        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: column_lower should be a str"):
+        with pytest.raises(
+            TypeError, match="DateDiffLeapYearTransformer: column_lower should be a str"
+        ):
 
             DateDiffLeapYearTransformer(
                 column_lower=123,
@@ -161,7 +165,9 @@ class TestInit(object):
     def test_column_upper_type_error(self):
         """Test that an exception is raised if column_upper is not a str."""
 
-        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: column_upper should be a str"):
+        with pytest.raises(
+            TypeError, match="DateDiffLeapYearTransformer: column_upper should be a str"
+        ):
 
             DateDiffLeapYearTransformer(
                 column_lower="dummy_1",
@@ -173,7 +179,10 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: new_column_name should be a str"):
+        with pytest.raises(
+            TypeError,
+            match="DateDiffLeapYearTransformer: new_column_name should be a str",
+        ):
 
             DateDiffLeapYearTransformer(
                 column_lower="dummy_1",
@@ -185,7 +194,9 @@ class TestInit(object):
     def test_drop_cols_type_error(self):
         """Test that an exception is raised if drop_cols is not a bool."""
 
-        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: drop_cols should be a bool"):
+        with pytest.raises(
+            TypeError, match="DateDiffLeapYearTransformer: drop_cols should be a bool"
+        ):
 
             DateDiffLeapYearTransformer(
                 column_lower="dummy_1",

--- a/tests/dates/test_DateDiffLeapYearTransformer.py
+++ b/tests/dates/test_DateDiffLeapYearTransformer.py
@@ -20,7 +20,7 @@ class TestCalculateAge(object):
             column_lower="a", column_upper="b", new_column_name="c", drop_cols=True
         )
 
-        with pytest.raises(TypeError, match="row should be a pd.Series"):
+        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: row should be a pd.Series"):
 
             date_transformer.calculate_age(row=row)
 
@@ -50,7 +50,7 @@ class TestCalculateAge(object):
 
         with pytest.raises(
             TypeError,
-            match="upper column values should be datetime.datetime or datetime.date objects",
+            match="DateDiffLeapYearTransformer: upper column values should be datetime.datetime or datetime.date objects",
         ):
 
             date_transformer.calculate_age(row=row)
@@ -65,7 +65,7 @@ class TestCalculateAge(object):
 
         with pytest.raises(
             TypeError,
-            match="lower column values should be datetime.datetime or datetime.date objects",
+            match="DateDiffLeapYearTransformer: lower column values should be datetime.datetime or datetime.date objects",
         ):
 
             date_transformer.calculate_age(row=row)
@@ -149,7 +149,7 @@ class TestInit(object):
     def test_column_lower_type_error(self):
         """Test that an exception is raised if column_lower is not a str."""
 
-        with pytest.raises(TypeError, match="column_lower should be a str"):
+        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: column_lower should be a str"):
 
             DateDiffLeapYearTransformer(
                 column_lower=123,
@@ -161,7 +161,7 @@ class TestInit(object):
     def test_column_upper_type_error(self):
         """Test that an exception is raised if column_upper is not a str."""
 
-        with pytest.raises(TypeError, match="column_upper should be a str"):
+        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: column_upper should be a str"):
 
             DateDiffLeapYearTransformer(
                 column_lower="dummy_1",
@@ -173,7 +173,7 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="new_column_name should be a str"):
+        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: new_column_name should be a str"):
 
             DateDiffLeapYearTransformer(
                 column_lower="dummy_1",
@@ -185,7 +185,7 @@ class TestInit(object):
     def test_drop_cols_type_error(self):
         """Test that an exception is raised if drop_cols is not a bool."""
 
-        with pytest.raises(TypeError, match="drop_cols should be a bool"):
+        with pytest.raises(TypeError, match="DateDiffLeapYearTransformer: drop_cols should be a bool"):
 
             DateDiffLeapYearTransformer(
                 column_lower="dummy_1",
@@ -199,7 +199,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match="if not None, missing_replacement should be an int, float or string",
+            match="DateDiffLeapYearTransformer: if not None, missing_replacement should be an int, float or string",
         ):
 
             DateDiffLeapYearTransformer(

--- a/tests/dates/test_DateDifferenceTransformer.py
+++ b/tests/dates/test_DateDifferenceTransformer.py
@@ -76,7 +76,9 @@ class TestInit(object):
     def test_column_lower_type_error(self):
         """Test that an exception is raised if column_lower is not a str."""
 
-        with pytest.raises(TypeError, match="DateDifferenceTransformer: column_lower must be a str"):
+        with pytest.raises(
+            TypeError, match="DateDifferenceTransformer: column_lower must be a str"
+        ):
 
             DateDifferenceTransformer(
                 column_lower=123,
@@ -90,7 +92,9 @@ class TestInit(object):
     def test_column_2_type_error(self):
         """Test that an exception is raised if column_upper is not a str."""
 
-        with pytest.raises(TypeError, match="DateDifferenceTransformer: column_upper must be a str"):
+        with pytest.raises(
+            TypeError, match="DateDifferenceTransformer: column_upper must be a str"
+        ):
 
             DateDifferenceTransformer(
                 column_lower="dummy_1",
@@ -104,7 +108,9 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="DateDifferenceTransformer: new_column_name must be a str"):
+        with pytest.raises(
+            TypeError, match="DateDifferenceTransformer: new_column_name must be a str"
+        ):
 
             DateDifferenceTransformer(
                 column_lower="dummy_1",
@@ -118,7 +124,9 @@ class TestInit(object):
     def test_units_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="DateDifferenceTransformer: units must be a str"):
+        with pytest.raises(
+            TypeError, match="DateDifferenceTransformer: units must be a str"
+        ):
 
             DateDifferenceTransformer(
                 column_lower="dummy_1",

--- a/tests/dates/test_DateDifferenceTransformer.py
+++ b/tests/dates/test_DateDifferenceTransformer.py
@@ -76,7 +76,7 @@ class TestInit(object):
     def test_column_lower_type_error(self):
         """Test that an exception is raised if column_lower is not a str."""
 
-        with pytest.raises(TypeError, match="column_lower must be a str"):
+        with pytest.raises(TypeError, match="DateDifferenceTransformer: column_lower must be a str"):
 
             DateDifferenceTransformer(
                 column_lower=123,
@@ -90,7 +90,7 @@ class TestInit(object):
     def test_column_2_type_error(self):
         """Test that an exception is raised if column_upper is not a str."""
 
-        with pytest.raises(TypeError, match="column_upper must be a str"):
+        with pytest.raises(TypeError, match="DateDifferenceTransformer: column_upper must be a str"):
 
             DateDifferenceTransformer(
                 column_lower="dummy_1",
@@ -104,7 +104,7 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="new_column_name must be a str"):
+        with pytest.raises(TypeError, match="DateDifferenceTransformer: new_column_name must be a str"):
 
             DateDifferenceTransformer(
                 column_lower="dummy_1",
@@ -118,7 +118,7 @@ class TestInit(object):
     def test_units_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="units must be a str"):
+        with pytest.raises(TypeError, match="DateDifferenceTransformer: units must be a str"):
 
             DateDifferenceTransformer(
                 column_lower="dummy_1",
@@ -134,7 +134,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=r"units must be one of \['Y', 'M', 'D', 'h', 'm', 's'\], got y",
+            match=r"DateDifferenceTransformer: units must be one of \['Y', 'M', 'D', 'h', 'm', 's'\], got y",
         ):
 
             DateDifferenceTransformer(

--- a/tests/dates/test_SeriesDtMethodTransformer.py
+++ b/tests/dates/test_SeriesDtMethodTransformer.py
@@ -68,7 +68,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"column should be a str but got \<class 'list'\>",
+            match=r"SeriesDtMethodTransformer: column should be a str but got \<class 'list'\>",
         ):
 
             SeriesDtMethodTransformer(
@@ -77,14 +77,14 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'int'\>\) for pd_method_name, expecting str",
+            match=r"SeriesDtMethodTransformer: unexpected type \(\<class 'int'\>\) for pd_method_name, expecting str",
         ):
 
             SeriesDtMethodTransformer(new_column_name="a", pd_method_name=1, column="b")
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'float'\>\) for new_column_name, must be str",
+            match=r"SeriesDtMethodTransformer: unexpected type \(\<class 'float'\>\) for new_column_name, must be str",
         ):
 
             SeriesDtMethodTransformer(
@@ -93,7 +93,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""pd_method_kwargs should be a dict but got type \<class 'int'\>""",
+            match=r"""SeriesDtMethodTransformer: pd_method_kwargs should be a dict but got type \<class 'int'\>""",
         ):
 
             SeriesDtMethodTransformer(
@@ -105,7 +105,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'int'\>\) for pd_method_kwargs key in position 1, must be str""",
+            match=r"""SeriesDtMethodTransformer: unexpected type \(\<class 'int'\>\) for pd_method_kwargs key in position 1, must be str""",
         ):
 
             SeriesDtMethodTransformer(
@@ -120,7 +120,7 @@ class TestInit(object):
 
         with pytest.raises(
             AttributeError,
-            match="""error accessing "dt.b" method on pd.Series object - pd_method_name should be a pd.Series.dt method""",
+            match="""SeriesDtMethodTransformer: error accessing "dt.b" method on pd.Series object - pd_method_name should be a pd.Series.dt method""",
         ):
 
             SeriesDtMethodTransformer(

--- a/tests/dates/test_ToDatetimeTransformer.py
+++ b/tests/dates/test_ToDatetimeTransformer.py
@@ -70,7 +70,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match="SeriesDtMethodTransformer: column should be a single str giving the column to transform to datetime",
+            match="ToDatetimeTransformer: column should be a single str giving the column to transform to datetime",
         ):
 
             ToDatetimeTransformer(
@@ -82,7 +82,7 @@ class TestInit(object):
         """Test that an exception is raised if new_column_name is not a str."""
 
         with pytest.raises(
-            TypeError, match="SeriesDtMethodTransformer: new_column_name must be a str"
+            TypeError, match="ToDatetimeTransformer: new_column_name must be a str"
         ):
 
             ToDatetimeTransformer(column="b", new_column_name=1)
@@ -92,7 +92,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""SeriesDtMethodTransformer: to_datetime_kwargs should be a dict but got type \<class 'int'\>""",
+            match=r"""ToDatetimeTransformer: to_datetime_kwargs should be a dict but got type \<class 'int'\>""",
         ):
 
             ToDatetimeTransformer(column="b", new_column_name="a", to_datetime_kwargs=1)
@@ -102,7 +102,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""SeriesDtMethodTransformer: unexpected type \(\<class 'int'\>\) for to_datetime_kwargs key in position 1, must be str""",
+            match=r"""ToDatetimeTransformer: unexpected type \(\<class 'int'\>\) for to_datetime_kwargs key in position 1, must be str""",
         ):
 
             ToDatetimeTransformer(

--- a/tests/dates/test_ToDatetimeTransformer.py
+++ b/tests/dates/test_ToDatetimeTransformer.py
@@ -81,7 +81,9 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="SeriesDtMethodTransformer: new_column_name must be a str"):
+        with pytest.raises(
+            TypeError, match="SeriesDtMethodTransformer: new_column_name must be a str"
+        ):
 
             ToDatetimeTransformer(column="b", new_column_name=1)
 

--- a/tests/dates/test_ToDatetimeTransformer.py
+++ b/tests/dates/test_ToDatetimeTransformer.py
@@ -70,7 +70,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match="column should be a single str giving the column to transform to datetime",
+            match="SeriesDtMethodTransformer: column should be a single str giving the column to transform to datetime",
         ):
 
             ToDatetimeTransformer(
@@ -81,7 +81,7 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="new_column_name must be a str"):
+        with pytest.raises(TypeError, match="SeriesDtMethodTransformer: new_column_name must be a str"):
 
             ToDatetimeTransformer(column="b", new_column_name=1)
 
@@ -90,7 +90,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""to_datetime_kwargs should be a dict but got type \<class 'int'\>""",
+            match=r"""SeriesDtMethodTransformer: to_datetime_kwargs should be a dict but got type \<class 'int'\>""",
         ):
 
             ToDatetimeTransformer(column="b", new_column_name="a", to_datetime_kwargs=1)
@@ -100,7 +100,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'int'\>\) for to_datetime_kwargs key in position 1, must be str""",
+            match=r"""SeriesDtMethodTransformer: unexpected type \(\<class 'int'\>\) for to_datetime_kwargs key in position 1, must be str""",
         ):
 
             ToDatetimeTransformer(

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -51,7 +51,8 @@ class TestInit(object):
         """Test that an exception is raised if columns is passed as None."""
 
         with pytest.raises(
-            ValueError, match="ArbitraryImputer: columns must be specified in init for ArbitraryImputer"
+            ValueError,
+            match="ArbitraryImputer: columns must be specified in init for ArbitraryImputer",
         ):
 
             ArbitraryImputer(impute_value=1, columns=None)
@@ -60,7 +61,8 @@ class TestInit(object):
         """Test that an exception is raised if impute_value is not an int, float or str."""
 
         with pytest.raises(
-            ValueError, match="ArbitraryImputer: impute_value should be a single value .*"
+            ValueError,
+            match="ArbitraryImputer: impute_value should be a single value .*",
         ):
 
             ArbitraryImputer(impute_value={}, columns="a")

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -51,7 +51,7 @@ class TestInit(object):
         """Test that an exception is raised if columns is passed as None."""
 
         with pytest.raises(
-            ValueError, match="columns must be specified in init for ArbitraryImputer"
+            ValueError, match="ArbitraryImputer: columns must be specified in init for ArbitraryImputer"
         ):
 
             ArbitraryImputer(impute_value=1, columns=None)
@@ -60,7 +60,7 @@ class TestInit(object):
         """Test that an exception is raised if impute_value is not an int, float or str."""
 
         with pytest.raises(
-            ValueError, match="impute_value should be a single value .*"
+            ValueError, match="ArbitraryImputer: impute_value should be a single value .*"
         ):
 
             ArbitraryImputer(impute_value={}, columns="a")

--- a/tests/imputers/test_NearestMeanResponseImputer.py
+++ b/tests/imputers/test_NearestMeanResponseImputer.py
@@ -94,7 +94,7 @@ class TestFit(object):
 
         x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        with pytest.raises(ValueError, match="y has 1 null values"):
+        with pytest.raises(ValueError, match="NearestMeanResponseImputer: y has 1 null values"):
 
             x.fit(df, df["c"])
 
@@ -109,7 +109,7 @@ class TestFit(object):
 
         with pytest.raises(
             ValueError,
-            match="Column a has no missing values, cannot use this transformer.",
+            match="NearestMeanResponseImputer: Column a has no missing values, cannot use this transformer.",
         ):
 
             x.fit(df, df["c"])

--- a/tests/imputers/test_NearestMeanResponseImputer.py
+++ b/tests/imputers/test_NearestMeanResponseImputer.py
@@ -94,7 +94,9 @@ class TestFit(object):
 
         x = NearestMeanResponseImputer(columns=["a", "b"])
 
-        with pytest.raises(ValueError, match="NearestMeanResponseImputer: y has 1 null values"):
+        with pytest.raises(
+            ValueError, match="NearestMeanResponseImputer: y has 1 null values"
+        ):
 
             x.fit(df, df["c"])
 

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -50,7 +50,7 @@ class TestInit(object):
     def test_no_keys_dict_error(self):
         """Test that an exception is raised if mappings is a dict but with no keys."""
 
-        with pytest.raises(ValueError, match="mappings has no values"):
+        with pytest.raises(ValueError, match="BaseMappingTransformer: mappings has no values"):
 
             BaseMappingTransformer(mappings={})
 
@@ -58,7 +58,7 @@ class TestInit(object):
         """Test that an exception is raised if mappings contains non-dict items."""
 
         with pytest.raises(
-            ValueError, match="values in mappings dictionary should be dictionaries"
+            ValueError, match="BaseMappingTransformer: values in mappings dictionary should be dictionaries"
         ):
 
             BaseMappingTransformer(mappings={"a": {"a": 1}, "b": 1})
@@ -66,7 +66,7 @@ class TestInit(object):
     def test_mappings_not_dict_error(self):
         """Test that an exception is raised if mappings is not a dict."""
 
-        with pytest.raises(ValueError, match="mappings must be a dictionary"):
+        with pytest.raises(ValueError, match="BaseMappingTransformer: mappings must be a dictionary"):
 
             BaseMappingTransformer(mappings=())
 

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -50,7 +50,9 @@ class TestInit(object):
     def test_no_keys_dict_error(self):
         """Test that an exception is raised if mappings is a dict but with no keys."""
 
-        with pytest.raises(ValueError, match="BaseMappingTransformer: mappings has no values"):
+        with pytest.raises(
+            ValueError, match="BaseMappingTransformer: mappings has no values"
+        ):
 
             BaseMappingTransformer(mappings={})
 
@@ -58,7 +60,8 @@ class TestInit(object):
         """Test that an exception is raised if mappings contains non-dict items."""
 
         with pytest.raises(
-            ValueError, match="BaseMappingTransformer: values in mappings dictionary should be dictionaries"
+            ValueError,
+            match="BaseMappingTransformer: values in mappings dictionary should be dictionaries",
         ):
 
             BaseMappingTransformer(mappings={"a": {"a": 1}, "b": 1})
@@ -66,7 +69,9 @@ class TestInit(object):
     def test_mappings_not_dict_error(self):
         """Test that an exception is raised if mappings is not a dict."""
 
-        with pytest.raises(ValueError, match="BaseMappingTransformer: mappings must be a dictionary"):
+        with pytest.raises(
+            ValueError, match="BaseMappingTransformer: mappings must be a dictionary"
+        ):
 
             BaseMappingTransformer(mappings=())
 

--- a/tests/mapping/test_CrossColumnAddTransformer.py
+++ b/tests/mapping/test_CrossColumnAddTransformer.py
@@ -60,14 +60,19 @@ class TestInit(object):
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
 
-        with pytest.raises(TypeError, match="CrossColumnAddTransformer: adjust_column should be a string"):
+        with pytest.raises(
+            TypeError,
+            match="CrossColumnAddTransformer: adjust_column should be a string",
+        ):
 
             CrossColumnAddTransformer(mappings={"a": {"a": 1}}, adjust_column=1)
 
     def test_mapping_values_not_numeric_error(self):
         """Test that an exception is raised if mappings values are not numeric."""
 
-        with pytest.raises(TypeError, match="CrossColumnAddTransformer: mapping values must be numeric"):
+        with pytest.raises(
+            TypeError, match="CrossColumnAddTransformer: mapping values must be numeric"
+        ):
 
             CrossColumnAddTransformer(mappings={"a": {"a": "b"}}, adjust_column="b")
 
@@ -177,7 +182,9 @@ class TestTransform(object):
 
         x = CrossColumnAddTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(ValueError, match="CrossColumnAddTransformer: variable c is not in X"):
+        with pytest.raises(
+            ValueError, match="CrossColumnAddTransformer: variable c is not in X"
+        ):
 
             x.transform(df)
 
@@ -190,7 +197,10 @@ class TestTransform(object):
 
         x = CrossColumnAddTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(TypeError, match="CrossColumnAddTransformer: variable c must have numeric dtype."):
+        with pytest.raises(
+            TypeError,
+            match="CrossColumnAddTransformer: variable c must have numeric dtype.",
+        ):
 
             x.transform(df)
 

--- a/tests/mapping/test_CrossColumnAddTransformer.py
+++ b/tests/mapping/test_CrossColumnAddTransformer.py
@@ -60,14 +60,14 @@ class TestInit(object):
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
 
-        with pytest.raises(TypeError, match="adjust_column should be a string"):
+        with pytest.raises(TypeError, match="CrossColumnAddTransformer: adjust_column should be a string"):
 
             CrossColumnAddTransformer(mappings={"a": {"a": 1}}, adjust_column=1)
 
     def test_mapping_values_not_numeric_error(self):
         """Test that an exception is raised if mappings values are not numeric."""
 
-        with pytest.raises(TypeError, match="mapping values must be numeric"):
+        with pytest.raises(TypeError, match="CrossColumnAddTransformer: mapping values must be numeric"):
 
             CrossColumnAddTransformer(mappings={"a": {"a": "b"}}, adjust_column="b")
 
@@ -177,7 +177,7 @@ class TestTransform(object):
 
         x = CrossColumnAddTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(ValueError, match="variable c is not in X"):
+        with pytest.raises(ValueError, match="CrossColumnAddTransformer: variable c is not in X"):
 
             x.transform(df)
 
@@ -190,7 +190,7 @@ class TestTransform(object):
 
         x = CrossColumnAddTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(TypeError, match="variable c must have numeric dtype."):
+        with pytest.raises(TypeError, match="CrossColumnAddTransformer: variable c must have numeric dtype."):
 
             x.transform(df)
 

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -60,7 +60,10 @@ class TestInit(object):
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
 
-        with pytest.raises(TypeError, match="CrossColumnMappingTransformer: adjust_column should be a string"):
+        with pytest.raises(
+            TypeError,
+            match="CrossColumnMappingTransformer: adjust_column should be a string",
+        ):
 
             CrossColumnMappingTransformer(mappings={"a": {"a": 1}}, adjust_column=1)
 
@@ -180,7 +183,9 @@ class TestTransform(object):
 
         x = CrossColumnMappingTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(ValueError, match="CrossColumnMappingTransformer: variable c is not in X"):
+        with pytest.raises(
+            ValueError, match="CrossColumnMappingTransformer: variable c is not in X"
+        ):
 
             x.transform(df)
 

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -60,7 +60,7 @@ class TestInit(object):
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
 
-        with pytest.raises(TypeError, match="adjust_column should be a string"):
+        with pytest.raises(TypeError, match="CrossColumnMappingTransformer: adjust_column should be a string"):
 
             CrossColumnMappingTransformer(mappings={"a": {"a": 1}}, adjust_column=1)
 
@@ -69,7 +69,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match="mappings should be an ordered dict for 'replace' mappings using multiple columns",
+            match="CrossColumnMappingTransformer: mappings should be an ordered dict for 'replace' mappings using multiple columns",
         ):
 
             CrossColumnMappingTransformer(
@@ -180,7 +180,7 @@ class TestTransform(object):
 
         x = CrossColumnMappingTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(ValueError, match="variable c is not in X"):
+        with pytest.raises(ValueError, match="CrossColumnMappingTransformer: variable c is not in X"):
 
             x.transform(df)
 

--- a/tests/mapping/test_CrossColumnMultiplyTransformer.py
+++ b/tests/mapping/test_CrossColumnMultiplyTransformer.py
@@ -60,14 +60,20 @@ class TestInit(object):
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
 
-        with pytest.raises(TypeError, match="CrossColumnMultiplyTransformer: adjust_column should be a string"):
+        with pytest.raises(
+            TypeError,
+            match="CrossColumnMultiplyTransformer: adjust_column should be a string",
+        ):
 
             CrossColumnMultiplyTransformer(mappings={"a": {"a": 1}}, adjust_column=1)
 
     def test_mapping_values_not_numeric_error(self):
         """Test that an exception is raised if mappings values are not numeric."""
 
-        with pytest.raises(TypeError, match="CrossColumnMultiplyTransformer: mapping values must be numeric"):
+        with pytest.raises(
+            TypeError,
+            match="CrossColumnMultiplyTransformer: mapping values must be numeric",
+        ):
 
             CrossColumnMultiplyTransformer(
                 mappings={"a": {"a": "b"}}, adjust_column="b"
@@ -181,7 +187,9 @@ class TestTransform(object):
 
         x = CrossColumnMultiplyTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(ValueError, match="CrossColumnMultiplyTransformer: variable c is not in X"):
+        with pytest.raises(
+            ValueError, match="CrossColumnMultiplyTransformer: variable c is not in X"
+        ):
 
             x.transform(df)
 
@@ -194,7 +202,10 @@ class TestTransform(object):
 
         x = CrossColumnMultiplyTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(TypeError, match="CrossColumnMultiplyTransformer: variable c must have numeric dtype."):
+        with pytest.raises(
+            TypeError,
+            match="CrossColumnMultiplyTransformer: variable c must have numeric dtype.",
+        ):
 
             x.transform(df)
 

--- a/tests/mapping/test_CrossColumnMultiplyTransformer.py
+++ b/tests/mapping/test_CrossColumnMultiplyTransformer.py
@@ -60,14 +60,14 @@ class TestInit(object):
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
 
-        with pytest.raises(TypeError, match="adjust_column should be a string"):
+        with pytest.raises(TypeError, match="CrossColumnMultiplyTransformer: adjust_column should be a string"):
 
             CrossColumnMultiplyTransformer(mappings={"a": {"a": 1}}, adjust_column=1)
 
     def test_mapping_values_not_numeric_error(self):
         """Test that an exception is raised if mappings values are not numeric."""
 
-        with pytest.raises(TypeError, match="mapping values must be numeric"):
+        with pytest.raises(TypeError, match="CrossColumnMultiplyTransformer: mapping values must be numeric"):
 
             CrossColumnMultiplyTransformer(
                 mappings={"a": {"a": "b"}}, adjust_column="b"
@@ -181,7 +181,7 @@ class TestTransform(object):
 
         x = CrossColumnMultiplyTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(ValueError, match="variable c is not in X"):
+        with pytest.raises(ValueError, match="CrossColumnMultiplyTransformer: variable c is not in X"):
 
             x.transform(df)
 
@@ -194,7 +194,7 @@ class TestTransform(object):
 
         x = CrossColumnMultiplyTransformer(mappings=mapping, adjust_column="c")
 
-        with pytest.raises(TypeError, match="variable c must have numeric dtype."):
+        with pytest.raises(TypeError, match="CrossColumnMultiplyTransformer: variable c must have numeric dtype."):
 
             x.transform(df)
 

--- a/tests/mapping/test_MappingTransformer.py
+++ b/tests/mapping/test_MappingTransformer.py
@@ -98,7 +98,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=f"each item in mappings should be a dict but got type {type(1)} for key c",
+            match=f"MappingTransformer: each item in mappings should be a dict but got type {type(1)} for key c",
         ):
 
             MappingTransformer(mappings=mappings)

--- a/tests/nominal/test_BaseNominalTransformer.py
+++ b/tests/nominal/test_BaseNominalTransformer.py
@@ -105,7 +105,7 @@ class TestCheckMappableRows:
 
         with pytest.raises(
             ValueError,
-            match="nulls would be introduced into column b from levels not present in mapping",
+            match="BaseNominalTransformer: nulls would be introduced into column b from levels not present in mapping",
         ):
 
             x.check_mappable_rows(df)

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -61,35 +61,50 @@ class TestInit(object):
     def test_cut_off_percent_not_float_error(self):
         """Test that an exception is raised if cut_off_percent is not an float."""
 
-        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: cut_off_percent must be a float"):
+        with pytest.raises(
+            ValueError,
+            match="GroupRareLevelsTransformer: cut_off_percent must be a float",
+        ):
 
             GroupRareLevelsTransformer(cut_off_percent="a")
 
     def test_cut_off_percent_negative_error(self):
         """Test that an exception is raised if cut_off_percent is negative."""
 
-        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: cut_off_percent must be > 0 and < 1"):
+        with pytest.raises(
+            ValueError,
+            match="GroupRareLevelsTransformer: cut_off_percent must be > 0 and < 1",
+        ):
 
             GroupRareLevelsTransformer(cut_off_percent=-1.0)
 
     def test_cut_off_percent_gt_one_error(self):
         """Test that an exception is raised if cut_off_percent is greater than 1."""
 
-        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: cut_off_percent must be > 0 and < 1"):
+        with pytest.raises(
+            ValueError,
+            match="GroupRareLevelsTransformer: cut_off_percent must be > 0 and < 1",
+        ):
 
             GroupRareLevelsTransformer(cut_off_percent=2.0)
 
     def test_weight_not_str_error(self):
         """Test that an exception is raised if weight is not a str, if supplied."""
 
-        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: weight should be a single column"):
+        with pytest.raises(
+            ValueError,
+            match="GroupRareLevelsTransformer: weight should be a single column",
+        ):
 
             GroupRareLevelsTransformer(weight=2)
 
     def test_record_rare_levels_not_str_error(self):
         """Test that an exception is raised if record_rare_levels is not a bool."""
 
-        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: record_rare_levels must be a bool"):
+        with pytest.raises(
+            ValueError,
+            match="GroupRareLevelsTransformer: record_rare_levels must be a bool",
+        ):
 
             GroupRareLevelsTransformer(record_rare_levels=2)
 
@@ -149,7 +164,9 @@ class TestFit(object):
 
         x = GroupRareLevelsTransformer(columns=["b", "c"], weight="aaaa")
 
-        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: weight aaaa not in X"):
+        with pytest.raises(
+            ValueError, match="GroupRareLevelsTransformer: weight aaaa not in X"
+        ):
 
             x.fit(df)
 
@@ -234,7 +251,8 @@ class TestFit(object):
         df = d.create_df_10()
 
         with pytest.raises(
-            ValueError, match="GroupRareLevelsTransformer: rare_level_name must be of the same type of the columns"
+            ValueError,
+            match="GroupRareLevelsTransformer: rare_level_name must be of the same type of the columns",
         ):
 
             x = GroupRareLevelsTransformer(columns=["a", "b"], rare_level_name=2)
@@ -242,7 +260,8 @@ class TestFit(object):
             x.fit(df)
 
         with pytest.raises(
-            ValueError, match="GroupRareLevelsTransformer: rare_level_name must be of the same type of the columns"
+            ValueError,
+            match="GroupRareLevelsTransformer: rare_level_name must be of the same type of the columns",
         ):
 
             x = GroupRareLevelsTransformer(columns=["c"])

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -61,35 +61,35 @@ class TestInit(object):
     def test_cut_off_percent_not_float_error(self):
         """Test that an exception is raised if cut_off_percent is not an float."""
 
-        with pytest.raises(ValueError, match="cut_off_percent must be a float"):
+        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: cut_off_percent must be a float"):
 
             GroupRareLevelsTransformer(cut_off_percent="a")
 
     def test_cut_off_percent_negative_error(self):
         """Test that an exception is raised if cut_off_percent is negative."""
 
-        with pytest.raises(ValueError, match="cut_off_percent must be > 0 and < 1"):
+        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: cut_off_percent must be > 0 and < 1"):
 
             GroupRareLevelsTransformer(cut_off_percent=-1.0)
 
     def test_cut_off_percent_gt_one_error(self):
         """Test that an exception is raised if cut_off_percent is greater than 1."""
 
-        with pytest.raises(ValueError, match="cut_off_percent must be > 0 and < 1"):
+        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: cut_off_percent must be > 0 and < 1"):
 
             GroupRareLevelsTransformer(cut_off_percent=2.0)
 
     def test_weight_not_str_error(self):
         """Test that an exception is raised if weight is not a str, if supplied."""
 
-        with pytest.raises(ValueError, match="weight should be a single column"):
+        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: weight should be a single column"):
 
             GroupRareLevelsTransformer(weight=2)
 
     def test_record_rare_levels_not_str_error(self):
         """Test that an exception is raised if record_rare_levels is not a bool."""
 
-        with pytest.raises(ValueError, match="record_rare_levels must be a bool"):
+        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: record_rare_levels must be a bool"):
 
             GroupRareLevelsTransformer(record_rare_levels=2)
 
@@ -149,7 +149,7 @@ class TestFit(object):
 
         x = GroupRareLevelsTransformer(columns=["b", "c"], weight="aaaa")
 
-        with pytest.raises(ValueError, match="weight aaaa not in X"):
+        with pytest.raises(ValueError, match="GroupRareLevelsTransformer: weight aaaa not in X"):
 
             x.fit(df)
 
@@ -234,7 +234,7 @@ class TestFit(object):
         df = d.create_df_10()
 
         with pytest.raises(
-            ValueError, match="rare_level_name must be of the same type of the columns"
+            ValueError, match="GroupRareLevelsTransformer: rare_level_name must be of the same type of the columns"
         ):
 
             x = GroupRareLevelsTransformer(columns=["a", "b"], rare_level_name=2)
@@ -242,7 +242,7 @@ class TestFit(object):
             x.fit(df)
 
         with pytest.raises(
-            ValueError, match="rare_level_name must be of the same type of the columns"
+            ValueError, match="GroupRareLevelsTransformer: rare_level_name must be of the same type of the columns"
         ):
 
             x = GroupRareLevelsTransformer(columns=["c"])

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -72,7 +72,7 @@ class TestInit(object):
     def test_weights_column_not_str_error(self):
         """Test that an exception is raised if weights_column is not a str."""
 
-        with pytest.raises(TypeError, match="weights_column should be a str"):
+        with pytest.raises(TypeError, match="MeanResponseTransformer: weights_column should be a str"):
 
             MeanResponseTransformer(response_column="a", weights_column=1)
 
@@ -216,7 +216,7 @@ class TestFit(object):
 
         x = MeanResponseTransformer(weights_column="z", columns=["b", "d", "f"])
 
-        with pytest.raises(ValueError, match="weights column z not in X"):
+        with pytest.raises(ValueError, match="MeanResponseTransformer: weights column z not in X"):
 
             x.fit(df, df["a"])
 
@@ -227,7 +227,7 @@ class TestFit(object):
 
         x = MeanResponseTransformer(columns=["b"])
 
-        with pytest.raises(ValueError, match="y has 1 null values"):
+        with pytest.raises(ValueError, match="MeanResponseTransformer: y has 1 null values"):
 
             x.fit(df, df["a"])
 
@@ -375,7 +375,7 @@ class TestTransform(object):
 
         with pytest.raises(
             ValueError,
-            match="nulls would be introduced into column b from levels not present in mapping",
+            match="MeanResponseTransformer: nulls would be introduced into column b from levels not present in mapping",
         ):
 
             x.transform(df)

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -72,7 +72,9 @@ class TestInit(object):
     def test_weights_column_not_str_error(self):
         """Test that an exception is raised if weights_column is not a str."""
 
-        with pytest.raises(TypeError, match="MeanResponseTransformer: weights_column should be a str"):
+        with pytest.raises(
+            TypeError, match="MeanResponseTransformer: weights_column should be a str"
+        ):
 
             MeanResponseTransformer(response_column="a", weights_column=1)
 
@@ -216,7 +218,9 @@ class TestFit(object):
 
         x = MeanResponseTransformer(weights_column="z", columns=["b", "d", "f"])
 
-        with pytest.raises(ValueError, match="MeanResponseTransformer: weights column z not in X"):
+        with pytest.raises(
+            ValueError, match="MeanResponseTransformer: weights column z not in X"
+        ):
 
             x.fit(df, df["a"])
 
@@ -227,7 +231,9 @@ class TestFit(object):
 
         x = MeanResponseTransformer(columns=["b"])
 
-        with pytest.raises(ValueError, match="MeanResponseTransformer: y has 1 null values"):
+        with pytest.raises(
+            ValueError, match="MeanResponseTransformer: y has 1 null values"
+        ):
 
             x.fit(df, df["a"])
 

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -286,7 +286,7 @@ class TestTransform(object):
 
         with pytest.raises(
             ValueError,
-            match="nulls would be introduced into column a from levels not present in mapping",
+            match="NominalToIntegerTransformer: nulls would be introduced into column a from levels not present in mapping",
         ):
 
             x.transform(df)
@@ -385,7 +385,7 @@ class TestInverseTransform(object):
 
         with pytest.raises(
             ValueError,
-            match="nulls introduced from levels not present in mapping for column: b",
+            match="NominalToIntegerTransformer: nulls introduced from levels not present in mapping for column: b",
         ):
 
             x.inverse_transform(df_transformed)

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -237,7 +237,8 @@ class TestFit(object):
         x = OneHotEncodingTransformer(columns=["b", "c"])
 
         with pytest.raises(
-            ValueError, match="OneHotEncodingTransformer: column b has nulls - replace before proceeding"
+            ValueError,
+            match="OneHotEncodingTransformer: column b has nulls - replace before proceeding",
         ):
 
             x.fit(df)
@@ -390,7 +391,8 @@ class TestTransform(object):
         x.fit(df_train)
 
         with pytest.raises(
-            ValueError, match="OneHotEncodingTransformer: column b has nulls - replace before proceeding"
+            ValueError,
+            match="OneHotEncodingTransformer: column b has nulls - replace before proceeding",
         ):
 
             x.transform(df_test)

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -237,7 +237,7 @@ class TestFit(object):
         x = OneHotEncodingTransformer(columns=["b", "c"])
 
         with pytest.raises(
-            ValueError, match="column b has nulls - replace before proceeding"
+            ValueError, match="OneHotEncodingTransformer: column b has nulls - replace before proceeding"
         ):
 
             x.fit(df)
@@ -252,7 +252,7 @@ class TestFit(object):
 
         with pytest.raises(
             ValueError,
-            match="column b has over 100 unique values - consider another type of encoding",
+            match="OneHotEncodingTransformer: column b has over 100 unique values - consider another type of encoding",
         ):
 
             x.fit(df)
@@ -390,7 +390,7 @@ class TestTransform(object):
         x.fit(df_train)
 
         with pytest.raises(
-            ValueError, match="column b has nulls - replace before proceeding"
+            ValueError, match="OneHotEncodingTransformer: column b has nulls - replace before proceeding"
         ):
 
             x.transform(df_test)

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -72,7 +72,9 @@ class TestInit(object):
     def test_weights_column_not_str_error(self):
         """Test that an exception is raised if weights_column is not a str."""
 
-        with pytest.raises(TypeError, match="OrdinalEncoderTransformer: weights_column should be a str"):
+        with pytest.raises(
+            TypeError, match="OrdinalEncoderTransformer: weights_column should be a str"
+        ):
 
             OrdinalEncoderTransformer(weights_column=1)
 
@@ -216,7 +218,9 @@ class TestFit(object):
 
         x = OrdinalEncoderTransformer(weights_column="z", columns=["b", "d", "f"])
 
-        with pytest.raises(ValueError, match="OrdinalEncoderTransformer: weights column z not in X"):
+        with pytest.raises(
+            ValueError, match="OrdinalEncoderTransformer: weights column z not in X"
+        ):
 
             x.fit(df, df["a"])
 
@@ -227,7 +231,9 @@ class TestFit(object):
 
         x = OrdinalEncoderTransformer(columns=["b"])
 
-        with pytest.raises(ValueError, match="OrdinalEncoderTransformer: y has 1 null values"):
+        with pytest.raises(
+            ValueError, match="OrdinalEncoderTransformer: y has 1 null values"
+        ):
 
             x.fit(df, df["a"])
 

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -72,7 +72,7 @@ class TestInit(object):
     def test_weights_column_not_str_error(self):
         """Test that an exception is raised if weights_column is not a str."""
 
-        with pytest.raises(TypeError, match="weights_column should be a str"):
+        with pytest.raises(TypeError, match="OrdinalEncoderTransformer: weights_column should be a str"):
 
             OrdinalEncoderTransformer(weights_column=1)
 
@@ -216,7 +216,7 @@ class TestFit(object):
 
         x = OrdinalEncoderTransformer(weights_column="z", columns=["b", "d", "f"])
 
-        with pytest.raises(ValueError, match="weights column z not in X"):
+        with pytest.raises(ValueError, match="OrdinalEncoderTransformer: weights column z not in X"):
 
             x.fit(df, df["a"])
 
@@ -227,7 +227,7 @@ class TestFit(object):
 
         x = OrdinalEncoderTransformer(columns=["b"])
 
-        with pytest.raises(ValueError, match="y has 1 null values"):
+        with pytest.raises(ValueError, match="OrdinalEncoderTransformer: y has 1 null values"):
 
             x.fit(df, df["a"])
 
@@ -363,7 +363,7 @@ class TestTransform(object):
 
         with pytest.raises(
             ValueError,
-            match="nulls would be introduced into column b from levels not present in mapping",
+            match="OrdinalEncoderTransformer: nulls would be introduced into column b from levels not present in mapping",
         ):
 
             x.transform(df)

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -59,7 +59,7 @@ class TestInit(object):
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "column arg (name of column) should be a single str giving the column to discretise"
+                "CutTransformer: column arg (name of column) should be a single str giving the column to discretise"
             ),
         ):
 
@@ -71,7 +71,7 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="new_column_name must be a str"):
+        with pytest.raises(TypeError, match="CutTransformer: new_column_name must be a str"):
 
             CutTransformer(column="b", new_column_name=1)
 
@@ -90,7 +90,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'int'\>\) for cut_kwargs key in position 1, must be str""",
+            match=r"""CutTransformer: unexpected type \(\<class 'int'\>\) for cut_kwargs key in position 1, must be str""",
         ):
 
             CutTransformer(
@@ -235,7 +235,7 @@ class TestTransform(object):
         x = CutTransformer(column="b", new_column_name="d")
 
         with pytest.raises(
-            TypeError, match="b should be a numeric dtype but got object"
+            TypeError, match="CutTransformer: b should be a numeric dtype but got object"
         ):
 
             x.transform(df)

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -71,7 +71,9 @@ class TestInit(object):
     def test_new_column_name_type_error(self):
         """Test that an exception is raised if new_column_name is not a str."""
 
-        with pytest.raises(TypeError, match="CutTransformer: new_column_name must be a str"):
+        with pytest.raises(
+            TypeError, match="CutTransformer: new_column_name must be a str"
+        ):
 
             CutTransformer(column="b", new_column_name=1)
 
@@ -235,7 +237,8 @@ class TestTransform(object):
         x = CutTransformer(column="b", new_column_name="d")
 
         with pytest.raises(
-            TypeError, match="CutTransformer: b should be a numeric dtype but got object"
+            TypeError,
+            match="CutTransformer: b should be a numeric dtype but got object",
         ):
 
             x.transform(df)

--- a/tests/numeric/test_InteractionTransformer.py
+++ b/tests/numeric/test_InteractionTransformer.py
@@ -71,7 +71,7 @@ class TestInit(object):
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "columns must be a string or list with the columns to be pre-processed (if specified)"
+                "InteractionTransformer: columns must be a string or list with the columns to be pre-processed (if specified)"
             ),
         ):
 
@@ -84,7 +84,7 @@ class TestInit(object):
         with pytest.raises(
             TypeError,
             match=re.escape(
-                "each element of columns should be a single (string) column name"
+                "InteractionTransformer: each element of columns should be a single (string) column name"
             ),
         ):
 
@@ -96,7 +96,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'str'\>\) for min_degree, must be int""",
+            match=r"""InteractionTransformer: unexpected type \(\<class 'str'\>\) for min_degree, must be int""",
         ):
 
             InteractionTransformer(
@@ -106,7 +106,7 @@ class TestInit(object):
             )
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'str'\>\) for max_degree, must be int""",
+            match=r"""InteractionTransformer: unexpected type \(\<class 'str'\>\) for max_degree, must be int""",
         ):
 
             InteractionTransformer(
@@ -119,7 +119,7 @@ class TestInit(object):
         """Test and exception is raised if degrees or columns provided are inconsistent."""
         with pytest.raises(
             ValueError,
-            match=r"""number of columns must be equal or greater than 2, got 1 column.""",
+            match=r"""InteractionTransformer: number of columns must be equal or greater than 2, got 1 column.""",
         ):
 
             InteractionTransformer(
@@ -128,7 +128,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=r"""min_degree must be equal or greater than 2, got 0""",
+            match=r"""InteractionTransformer: min_degree must be equal or greater than 2, got 0""",
         ):
 
             InteractionTransformer(
@@ -139,7 +139,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=r"""max_degree must be equal or greater than min_degree""",
+            match=r"""InteractionTransformer: max_degree must be equal or greater than min_degree""",
         ):
 
             InteractionTransformer(
@@ -150,7 +150,7 @@ class TestInit(object):
         # NEW
         with pytest.raises(
             ValueError,
-            match=r"""max_degree must be equal or lower than number of columns""",
+            match=r"""InteractionTransformer: max_degree must be equal or lower than number of columns""",
         ):
 
             InteractionTransformer(

--- a/tests/numeric/test_LogTransformer.py
+++ b/tests/numeric/test_LogTransformer.py
@@ -211,7 +211,8 @@ class TestTransform(object):
         x = LogTransformer(columns=["a", "b", "c"])
 
         with pytest.raises(
-            TypeError, match=r"LogTransformer: The following columns are not numeric in X; \['b', 'c'\]"
+            TypeError,
+            match=r"LogTransformer: The following columns are not numeric in X; \['b', 'c'\]",
         ):
 
             x.transform(df)

--- a/tests/numeric/test_LogTransformer.py
+++ b/tests/numeric/test_LogTransformer.py
@@ -26,7 +26,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=re.escape("base should be numeric or None"),
+            match=re.escape("LogTransformer: base should be numeric or None"),
         ):
 
             LogTransformer(
@@ -40,7 +40,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=re.escape("base should be strictly positive"),
+            match=re.escape("LogTransformer: base should be strictly positive"),
         ):
 
             LogTransformer(
@@ -211,7 +211,7 @@ class TestTransform(object):
         x = LogTransformer(columns=["a", "b", "c"])
 
         with pytest.raises(
-            TypeError, match=r"The following columns are not numeric in X; \['b', 'c'\]"
+            TypeError, match=r"LogTransformer: The following columns are not numeric in X; \['b', 'c'\]"
         ):
 
             x.transform(df)
@@ -367,7 +367,7 @@ class TestTransform(object):
 
         with pytest.raises(
             ValueError,
-            match=f"values less than or equal to 0 in columns{extra_exception_text}, make greater than 0 before using transform",
+            match=f"LogTransformer: values less than or equal to 0 in columns{extra_exception_text}, make greater than 0 before using transform",
         ):
 
             x.transform(df)

--- a/tests/numeric/test_ScalingTransformer.py
+++ b/tests/numeric/test_ScalingTransformer.py
@@ -32,7 +32,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""scaler_kwargs should be a dict but got type \<class 'int'\>""",
+            match=r"""ScalingTransformer: scaler_kwargs should be a dict but got type \<class 'int'\>""",
         ):
 
             ScalingTransformer(columns="b", scaler_type="standard", scaler_kwargs=1)
@@ -42,7 +42,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'int'\>\) for scaler_kwargs key in position 1, must be str""",
+            match=r"""ScalingTransformer: unexpected type \(\<class 'int'\>\) for scaler_kwargs key in position 1, must be str""",
         ):
 
             ScalingTransformer(
@@ -56,7 +56,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match=r"""scaler_type should be one of; \['min_max', 'max_abs', 'standard'\]""",
+            match=r"""ScalingTransformer: scaler_type should be one of; \['min_max', 'max_abs', 'standard'\]""",
         ):
 
             ScalingTransformer(columns="b", scaler_type="zzz", scaler_kwargs={"a": 1})
@@ -157,7 +157,7 @@ class TestCheckNumericColumns(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""The following columns are not numeric in X; \['b', 'c'\]""",
+            match=r"""ScalingTransformer: The following columns are not numeric in X; \['b', 'c'\]""",
         ):
 
             x.check_numeric_columns(df)

--- a/tests/strings/test_SeriesStrMethodTransformer.py
+++ b/tests/strings/test_SeriesStrMethodTransformer.py
@@ -72,7 +72,7 @@ class TestInit(object):
 
         with pytest.raises(
             ValueError,
-            match="columns arg should contain only 1 column name but got 2",
+            match="SeriesStrMethodTransformer: columns arg should contain only 1 column name but got 2",
         ):
 
             SeriesStrMethodTransformer(
@@ -81,7 +81,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'int'\>\) for pd_method_name, expecting str",
+            match=r"SeriesStrMethodTransformer: unexpected type \(\<class 'int'\>\) for pd_method_name, expecting str",
         ):
 
             SeriesStrMethodTransformer(
@@ -90,7 +90,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"unexpected type \(\<class 'float'\>\) for new_column_name, must be str",
+            match=r"SeriesStrMethodTransformer: unexpected type \(\<class 'float'\>\) for new_column_name, must be str",
         ):
 
             SeriesStrMethodTransformer(
@@ -99,7 +99,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""pd_method_kwargs should be a dict but got type \<class 'int'\>""",
+            match=r"""SeriesStrMethodTransformer: pd_method_kwargs should be a dict but got type \<class 'int'\>""",
         ):
 
             SeriesStrMethodTransformer(
@@ -111,7 +111,7 @@ class TestInit(object):
 
         with pytest.raises(
             TypeError,
-            match=r"""unexpected type \(\<class 'int'\>\) for pd_method_kwargs key in position 1, must be str""",
+            match=r"""SeriesStrMethodTransformer: unexpected type \(\<class 'int'\>\) for pd_method_kwargs key in position 1, must be str""",
         ):
 
             SeriesStrMethodTransformer(
@@ -126,7 +126,7 @@ class TestInit(object):
 
         with pytest.raises(
             AttributeError,
-            match="""error accessing "str.b" method on pd.Series object - pd_method_name should be a pd.Series.str method""",
+            match="""SeriesStrMethodTransformer: error accessing "str.b" method on pd.Series object - pd_method_name should be a pd.Series.str method""",
         ):
 
             SeriesStrMethodTransformer(

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -49,7 +49,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         Version number (__version__ attribute from _version.py).
 
     """
-    
+
     def classname(self):
         """Method that returns the name of the current class when called"""
         return type(self).__name__

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -56,7 +56,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(verbose, bool):
 
-            raise TypeError("verbose must be a bool")
+            raise TypeError(f"{self.classname()}: verbose must be a bool")
 
         else:
 
@@ -81,14 +81,14 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
                 if not len(columns) > 0:
 
-                    raise ValueError("columns has no values")
+                    raise ValueError(f"{self.classname()}: columns has no values")
 
                 for c in columns:
 
                     if not isinstance(c, str):
 
                         raise TypeError(
-                            "each element of columns should be a single (string) column name"
+                            f"{self.classname()}: each element of columns should be a single (string) column name"
                         )
 
                 self.columns = columns
@@ -96,12 +96,12 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
             else:
 
                 raise TypeError(
-                    "columns must be a string or list with the columns to be pre-processed (if specified)"
+                    f"{self.classname()}: columns must be a string or list with the columns to be pre-processed (if specified)"
                 )
 
         if not isinstance(copy, bool):
 
-            raise TypeError("copy must be a bool")
+            raise TypeError(f"{self.classname()}: copy must be a bool")
 
         else:
 
@@ -132,17 +132,17 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not X.shape[0] > 0:
 
-            raise ValueError(f"X has no rows; {X.shape}")
+            raise ValueError(f"{self.classname()}: X has no rows; {X.shape}")
 
         if y is not None:
 
             if not isinstance(y, pd.Series):
 
-                raise TypeError("unexpected type for y, should be a pd.Series")
+                raise TypeError(f"{self.classname()}: unexpected type for y, should be a pd.Series")
 
             if not y.shape[0] > 0:
 
-                raise ValueError(f"y is empty; {y.shape}")
+                raise ValueError(f"{self.classname()}: y is empty; {y.shape}")
 
         return self
 
@@ -166,21 +166,21 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(X, pd.DataFrame):
 
-            raise TypeError("X should be a pd.DataFrame")
+            raise TypeError(f"{self.classname()}: X should be a pd.DataFrame")
 
         if not isinstance(y, pd.Series):
 
-            raise TypeError("y should be a pd.Series")
+            raise TypeError(f"{self.classname()}: y should be a pd.Series")
 
         if X.shape[0] != y.shape[0]:
 
             raise ValueError(
-                f"X and y have different numbers of rows ({X.shape[0]} vs {y.shape[0]})"
+                f"{self.classname()}: X and y have different numbers of rows ({X.shape[0]} vs {y.shape[0]})"
             )
 
         if not (X.index == y.index).all():
 
-            warnings.warn("X and y do not have equal indexes")
+            warnings.warn(f"{self.classname()}: X and y do not have equal indexes")
 
         X_y = X.copy()
 
@@ -217,7 +217,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not X.shape[0] > 0:
 
-            raise ValueError(f"X has no rows; {X.shape}")
+            raise ValueError(f"{self.classname()}: X has no rows; {X.shape}")
 
         return X
 
@@ -248,21 +248,21 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(X, pd.DataFrame):
 
-            raise TypeError("X should be a pd.DataFrame")
+            raise TypeError(f"{self.classname()}: X should be a pd.DataFrame")
 
         if self.columns is None:
 
-            raise ValueError("columns not set")
+            raise ValueError(f"{self.classname()}: columns not set")
 
         if not isinstance(self.columns, list):
 
-            raise TypeError("self.columns should be a list")
+            raise TypeError(f"{self.classname()}: self.columns should be a list")
 
         for c in self.columns:
 
             if c not in X.columns.values:
 
-                raise ValueError("variable " + c + " is not in X")
+                raise ValueError(f"{self.classname()}: variable " + c + " is not in X")
 
     def columns_set_or_check(self, X):
         """Function to check or set columns attribute.
@@ -278,7 +278,7 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
         if not isinstance(X, pd.DataFrame):
 
-            raise TypeError("X should be a pd.DataFrame")
+            raise TypeError(f"{self.classname()}: X should be a pd.DataFrame")
 
         if self.columns is None:
 
@@ -287,6 +287,10 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         else:
 
             self.columns_check(X)
+
+    def classname(self):
+        """Method that returns the name of the current class when called"""
+        return type(self).__name__
 
 
 class ReturnKeyDict(dict):
@@ -381,25 +385,25 @@ class DataFrameMethodTransformer(BaseTransformer):
                 if not type(item) is str:
 
                     raise TypeError(
-                        f"if new_column_name is a list, all elements must be strings but got {type(item)} in position {i}"
+                        f"{self.classname()}: if new_column_name is a list, all elements must be strings but got {type(item)} in position {i}"
                     )
 
         elif not type(new_column_name) is str:
 
             raise TypeError(
-                f"unexpected type ({type(new_column_name)}) for new_column_name, must be str or list of strings"
+                f"{self.classname()}: unexpected type ({type(new_column_name)}) for new_column_name, must be str or list of strings"
             )
 
         if not type(pd_method_name) is str:
 
             raise TypeError(
-                f"unexpected type ({type(pd_method_name)}) for pd_method_name, expecting str"
+                f"{self.classname()}: unexpected type ({type(pd_method_name)}) for pd_method_name, expecting str"
             )
 
         if not type(pd_method_kwargs) is dict:
 
             raise TypeError(
-                f"pd_method_kwargs should be a dict but got type {type(pd_method_kwargs)}"
+                f"{self.classname()}: pd_method_kwargs should be a dict but got type {type(pd_method_kwargs)}"
             )
 
         else:
@@ -409,13 +413,13 @@ class DataFrameMethodTransformer(BaseTransformer):
                 if not type(k) is str:
 
                     raise TypeError(
-                        f"unexpected type ({type(k)}) for pd_method_kwargs key in position {i}, must be str"
+                        f"{self.classname()}: unexpected type ({type(k)}) for pd_method_kwargs key in position {i}, must be str"
                     )
 
         if not type(drop_original) is bool:
 
             raise TypeError(
-                f"unexpected type ({type(drop_original)}) for drop_original, expecting bool"
+                f"{self.classname()}: unexpected type ({type(drop_original)}) for drop_original, expecting bool"
             )
 
         self.new_column_name = new_column_name
@@ -431,7 +435,7 @@ class DataFrameMethodTransformer(BaseTransformer):
         except Exception as err:
 
             raise AttributeError(
-                f"""error accessing "{pd_method_name}" method on pd.DataFrame object - pd_method_name should be a pd.DataFrame method"""
+                f"""{self.classname()}: error accessing "{pd_method_name}" method on pd.DataFrame object - pd_method_name should be a pd.DataFrame method"""
             ) from err
 
     def transform(self, X):

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -138,7 +138,9 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
 
             if not isinstance(y, pd.Series):
 
-                raise TypeError(f"{self.classname()}: unexpected type for y, should be a pd.Series")
+                raise TypeError(
+                    f"{self.classname()}: unexpected type for y, should be a pd.Series"
+                )
 
             if not y.shape[0] > 0:
 

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -49,6 +49,10 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         Version number (__version__ attribute from _version.py).
 
     """
+    
+    def classname(self):
+        """Method that returns the name of the current class when called"""
+        return type(self).__name__
 
     def __init__(self, columns=None, copy=True, verbose=False, **kwargs):
 
@@ -289,10 +293,6 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
         else:
 
             self.columns_check(X)
-
-    def classname(self):
-        """Method that returns the name of the current class when called"""
-        return type(self).__name__
 
 
 class ReturnKeyDict(dict):

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -114,7 +114,9 @@ class CappingTransformer(BaseTransformer):
 
         if type(capping_values_dict) is not dict:
 
-            raise TypeError(f"{self.classname()}: {dict_name} should be dict of columns and capping values")
+            raise TypeError(
+                f"{self.classname()}: {dict_name} should be dict of columns and capping values"
+            )
 
         for k, cap_values in capping_values_dict.items():
 
@@ -162,7 +164,9 @@ class CappingTransformer(BaseTransformer):
 
             if all([cap_value is None for cap_value in cap_values]):
 
-                raise ValueError(f"{self.classname()}: both values are None for key {k}")
+                raise ValueError(
+                    f"{self.classname()}: both values are None for key {k}"
+                )
 
     def fit(self, X, y=None):
         """Learn capping values from input data X.
@@ -203,7 +207,9 @@ class CappingTransformer(BaseTransformer):
 
         else:
 
-            warnings.warn(f"{self.classname()}: quantiles not set so no fitting done in CappingTransformer")
+            warnings.warn(
+                f"{self.classname()}: quantiles not set so no fitting done in CappingTransformer"
+            )
 
         self._replacement_values = copy.deepcopy(self.capping_values)
 
@@ -331,7 +337,9 @@ class CappingTransformer(BaseTransformer):
             raise ValueError(f"{self.classname()}: negative weights in sample weights")
 
         if sample_weight.sum() <= 0:
-            raise ValueError(f"{self.classname()}: total sample weights are not greater than 0")
+            raise ValueError(
+                f"{self.classname()}: total sample weights are not greater than 0"
+            )
 
         values = np.array(values)
         quantiles = np.array(quantiles)

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -67,14 +67,14 @@ class CappingTransformer(BaseTransformer):
         if capping_values is None and quantiles is None:
 
             raise ValueError(
-                "both capping_values and quantiles are None, either supply capping values in the "
+                f"{self.classname()}: both capping_values and quantiles are None, either supply capping values in the "
                 "capping_values argument or supply quantiles that can be learnt in the fit method"
             )
 
         if capping_values is not None and quantiles is not None:
 
             raise ValueError(
-                "both capping_values and quantiles are not None, supply one or the other"
+                f"{self.classname()}: both capping_values and quantiles are not None, supply one or the other"
             )
 
         if capping_values is not None:
@@ -98,7 +98,7 @@ class CappingTransformer(BaseTransformer):
                         if quantile_value < 0 or quantile_value > 1:
 
                             raise ValueError(
-                                f"quantile values must be in the range [0, 1] but got {quantile_value} for key {k}"
+                                f"{self.classname()}: quantile values must be in the range [0, 1] but got {quantile_value} for key {k}"
                             )
 
             self.capping_values = {}
@@ -114,26 +114,26 @@ class CappingTransformer(BaseTransformer):
 
         if type(capping_values_dict) is not dict:
 
-            raise TypeError(f"{dict_name} should be dict of columns and capping values")
+            raise TypeError(f"{self.classname()}: {dict_name} should be dict of columns and capping values")
 
         for k, cap_values in capping_values_dict.items():
 
             if type(k) is not str:
 
                 raise TypeError(
-                    f"all keys in {dict_name} should be str, but got {type(k)}"
+                    f"{self.classname()}: all keys in {dict_name} should be str, but got {type(k)}"
                 )
 
             if type(cap_values) is not list:
 
                 raise TypeError(
-                    f"each item in {dict_name} should be a list, but got {type(cap_values)} for key {k}"
+                    f"{self.classname()}: each item in {dict_name} should be a list, but got {type(cap_values)} for key {k}"
                 )
 
             if len(cap_values) != 2:
 
                 raise ValueError(
-                    f"each item in {dict_name} should be length 2, but got {len(cap_values)} for key {k}"
+                    f"{self.classname()}: each item in {dict_name} should be length 2, but got {len(cap_values)} for key {k}"
                 )
 
             for cap_value in cap_values:
@@ -143,13 +143,13 @@ class CappingTransformer(BaseTransformer):
                     if type(cap_value) not in [int, float]:
 
                         raise TypeError(
-                            f"each item in {dict_name} lists must contain numeric values or None, got {type(cap_value)} for key {k}"
+                            f"{self.classname()}: each item in {dict_name} lists must contain numeric values or None, got {type(cap_value)} for key {k}"
                         )
 
                     if np.isnan(cap_value) or np.isinf(cap_value):
 
                         raise ValueError(
-                            f"item in {dict_name} lists contains numpy NaN or Inf values"
+                            f"{self.classname()}: item in {dict_name} lists contains numpy NaN or Inf values"
                         )
 
             if all([cap_value is not None for cap_value in cap_values]):
@@ -157,12 +157,12 @@ class CappingTransformer(BaseTransformer):
                 if cap_values[0] >= cap_values[1]:
 
                     raise ValueError(
-                        f"lower value is greater than or equal to upper value for key {k}"
+                        f"{self.classname()}: lower value is greater than or equal to upper value for key {k}"
                     )
 
             if all([cap_value is None for cap_value in cap_values]):
 
-                raise ValueError(f"both values are None for key {k}")
+                raise ValueError(f"{self.classname()}: both values are None for key {k}")
 
     def fit(self, X, y=None):
         """Learn capping values from input data X.
@@ -203,7 +203,7 @@ class CappingTransformer(BaseTransformer):
 
         else:
 
-            warnings.warn("quantiles not set so no fitting done in CappingTransformer")
+            warnings.warn(f"{self.classname()}: quantiles not set so no fitting done in CappingTransformer")
 
         self._replacement_values = copy.deepcopy(self.capping_values)
 
@@ -322,16 +322,16 @@ class CappingTransformer(BaseTransformer):
             sample_weight = np.array(sample_weight)
 
         if np.isnan(sample_weight).sum() > 0:
-            raise ValueError("null values in sample weights")
+            raise ValueError(f"{self.classname()}: null values in sample weights")
 
         if np.isinf(sample_weight).sum() > 0:
-            raise ValueError("infinite values in sample weights")
+            raise ValueError(f"{self.classname()}: infinite values in sample weights")
 
         if (sample_weight < 0).sum() > 0:
-            raise ValueError("negative weights in sample weights")
+            raise ValueError(f"{self.classname()}: negative weights in sample weights")
 
         if sample_weight.sum() <= 0:
-            raise ValueError("total sample weights are not greater than 0")
+            raise ValueError(f"{self.classname()}: total sample weights are not greater than 0")
 
         values = np.array(values)
         quantiles = np.array(quantiles)
@@ -379,13 +379,13 @@ class CappingTransformer(BaseTransformer):
         if self.capping_values == {}:
 
             raise ValueError(
-                "capping_values attribute is an empty dict - perhaps the fit method has not been run yet"
+                f"{self.classname()}: capping_values attribute is an empty dict - perhaps the fit method has not been run yet"
             )
 
         if self._replacement_values == {}:
 
             raise ValueError(
-                "_replacement_values attribute is an empty dict - perhaps the fit method has not been run yet"
+                f"{self.classname()}: _replacement_values attribute is an empty dict - perhaps the fit method has not been run yet"
             )
 
         X = super().transform(X)
@@ -401,7 +401,7 @@ class CappingTransformer(BaseTransformer):
             )
 
             raise TypeError(
-                f"The following columns are not numeric in X; {non_numeric_columns}"
+                f"{self.classname()}: The following columns are not numeric in X; {non_numeric_columns}"
             )
 
         for col in self.columns:

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -410,7 +410,9 @@ class SeriesDtMethodTransformer(BaseTransformer):
 
         if type(column) is not str:
 
-            raise TypeError(f"{self.classname()}: column should be a str but got {type(column)}")
+            raise TypeError(
+                f"{self.classname()}: column should be a str but got {type(column)}"
+            )
 
         super().__init__(columns=column, **kwargs)
 

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -66,21 +66,21 @@ class DateDiffLeapYearTransformer(BaseTransformer):
     ):
 
         if not isinstance(column_lower, str):
-            raise TypeError("column_lower should be a str")
+            raise TypeError(f"{self.classname()}: column_lower should be a str")
 
         if not isinstance(column_upper, str):
-            raise TypeError("column_upper should be a str")
+            raise TypeError(f"{self.classname()}: column_upper should be a str")
 
         if not isinstance(new_column_name, str):
-            raise TypeError("new_column_name should be a str")
+            raise TypeError(f"{self.classname()}: new_column_name should be a str")
 
         if not isinstance(drop_cols, bool):
-            raise TypeError("drop_cols should be a bool")
+            raise TypeError(f"{self.classname()}: drop_cols should be a bool")
 
         if missing_replacement:
             if not type(missing_replacement) in [int, float, str]:
                 raise TypeError(
-                    "if not None, missing_replacement should be an int, float or string"
+                    f"{self.classname()}: if not None, missing_replacement should be an int, float or string"
                 )
 
         super().__init__(columns=[column_lower, column_upper], **kwargs)
@@ -113,7 +113,7 @@ class DateDiffLeapYearTransformer(BaseTransformer):
         """
 
         if not isinstance(row, pd.Series):
-            raise TypeError("row should be a pd.Series")
+            raise TypeError(f"{self.classname()}: row should be a pd.Series")
 
         if (pd.isnull(row[self.columns[0]])) or (pd.isnull(row[self.columns[1]])):
             return self.missing_replacement
@@ -122,12 +122,12 @@ class DateDiffLeapYearTransformer(BaseTransformer):
 
             if not type(row[self.columns[1]]) in [datetime.date, datetime.datetime]:
                 raise TypeError(
-                    "upper column values should be datetime.datetime or datetime.date objects"
+                    f"{self.classname()}: upper column values should be datetime.datetime or datetime.date objects"
                 )
 
             if not type(row[self.columns[0]]) in [datetime.date, datetime.datetime]:
                 raise TypeError(
-                    "lower column values should be datetime.datetime or datetime.date objects"
+                    f"{self.classname()}: lower column values should be datetime.datetime or datetime.date objects"
                 )
 
             age = row[self.columns[1]].year - row[self.columns[0]].year
@@ -206,11 +206,11 @@ class DateDifferenceTransformer(BaseTransformer):
 
         if not type(column_lower) is str:
 
-            raise TypeError("column_lower must be a str")
+            raise TypeError(f"{self.classname()}: column_lower must be a str")
 
         if not type(column_upper) is str:
 
-            raise TypeError("column_upper must be a str")
+            raise TypeError(f"{self.classname()}: column_upper must be a str")
 
         columns = [column_lower, column_upper]
 
@@ -225,12 +225,12 @@ class DateDifferenceTransformer(BaseTransformer):
 
         if not type(units) is str:
 
-            raise TypeError("units must be a str")
+            raise TypeError(f"{self.classname()}: units must be a str")
 
         if units not in accepted_values_units:
 
             raise ValueError(
-                f"units must be one of {accepted_values_units}, got {units}"
+                f"{self.classname()}: units must be one of {accepted_values_units}, got {units}"
             )
 
         self.units = units
@@ -239,7 +239,7 @@ class DateDifferenceTransformer(BaseTransformer):
 
             if not type(new_column_name) is str:
 
-                raise TypeError("new_column_name must be a str")
+                raise TypeError(f"{self.classname()}: new_column_name must be a str")
 
             self.new_column_name = new_column_name
 
@@ -299,17 +299,17 @@ class ToDatetimeTransformer(BaseTransformer):
         if not type(column) is str:
 
             raise TypeError(
-                "column should be a single str giving the column to transform to datetime"
+                f"{self.classname()}: column should be a single str giving the column to transform to datetime"
             )
 
         if not type(new_column_name) is str:
 
-            raise TypeError("new_column_name must be a str")
+            raise TypeError(f"{self.classname()}: new_column_name must be a str")
 
         if not type(to_datetime_kwargs) is dict:
 
             raise TypeError(
-                f"to_datetime_kwargs should be a dict but got type {type(to_datetime_kwargs)}"
+                f"{self.classname()}: to_datetime_kwargs should be a dict but got type {type(to_datetime_kwargs)}"
             )
 
         else:
@@ -319,7 +319,7 @@ class ToDatetimeTransformer(BaseTransformer):
                 if not type(k) is str:
 
                     raise TypeError(
-                        f"unexpected type ({type(k)}) for to_datetime_kwargs key in position {i}, must be str"
+                        f"{self.classname()}: unexpected type ({type(k)}) for to_datetime_kwargs key in position {i}, must be str"
                     )
 
         self.to_datetime_kwargs = to_datetime_kwargs
@@ -410,26 +410,26 @@ class SeriesDtMethodTransformer(BaseTransformer):
 
         if type(column) is not str:
 
-            raise TypeError(f"column should be a str but got {type(column)}")
+            raise TypeError(f"{self.classname()}: column should be a str but got {type(column)}")
 
         super().__init__(columns=column, **kwargs)
 
         if type(new_column_name) is not str:
 
             raise TypeError(
-                f"unexpected type ({type(new_column_name)}) for new_column_name, must be str"
+                f"{self.classname()}: unexpected type ({type(new_column_name)}) for new_column_name, must be str"
             )
 
         if type(pd_method_name) is not str:
 
             raise TypeError(
-                f"unexpected type ({type(pd_method_name)}) for pd_method_name, expecting str"
+                f"{self.classname()}: unexpected type ({type(pd_method_name)}) for pd_method_name, expecting str"
             )
 
         if type(pd_method_kwargs) is not dict:
 
             raise TypeError(
-                f"pd_method_kwargs should be a dict but got type {type(pd_method_kwargs)}"
+                f"{self.classname()}: pd_method_kwargs should be a dict but got type {type(pd_method_kwargs)}"
             )
 
         else:
@@ -439,7 +439,7 @@ class SeriesDtMethodTransformer(BaseTransformer):
                 if not type(k) is str:
 
                     raise TypeError(
-                        f"unexpected type ({type(k)}) for pd_method_kwargs key in position {i}, must be str"
+                        f"{self.classname()}: unexpected type ({type(k)}) for pd_method_kwargs key in position {i}, must be str"
                     )
 
         self.new_column_name = new_column_name
@@ -454,7 +454,7 @@ class SeriesDtMethodTransformer(BaseTransformer):
         except Exception as err:
 
             raise AttributeError(
-                f"""error accessing "dt.{pd_method_name}" method on pd.Series object - pd_method_name should be a pd.Series.dt method"""
+                f"""{self.classname()}: error accessing "dt.{pd_method_name}" method on pd.Series object - pd_method_name should be a pd.Series.dt method"""
             ) from err
 
         if callable(getattr(ser.dt, pd_method_name)):
@@ -578,22 +578,22 @@ class BetweenDatesTransformer(BaseTransformer):
     ):
 
         if type(column_lower) is not str:
-            raise TypeError("column_lower should be str")
+            raise TypeError(f"{self.classname()}: column_lower should be str")
 
         if type(column_between) is not str:
-            raise TypeError("column_between should be str")
+            raise TypeError(f"{self.classname()}: column_between should be str")
 
         if type(column_upper) is not str:
-            raise TypeError("column_upper should be str")
+            raise TypeError(f"{self.classname()}: column_upper should be str")
 
         if type(new_column_name) is not str:
-            raise TypeError("new_column_name should be str")
+            raise TypeError(f"{self.classname()}: new_column_name should be str")
 
         if type(lower_inclusive) is not bool:
-            raise TypeError("lower_inclusive should be a bool")
+            raise TypeError(f"{self.classname()}: lower_inclusive should be a bool")
 
         if type(upper_inclusive) is not bool:
-            raise TypeError("upper_inclusive should be a bool")
+            raise TypeError(f"{self.classname()}: upper_inclusive should be a bool")
 
         self.new_column_name = new_column_name
         self.lower_inclusive = lower_inclusive
@@ -633,13 +633,13 @@ class BetweenDatesTransformer(BaseTransformer):
             if not pd.api.types.is_datetime64_dtype(X[col]):
 
                 raise TypeError(
-                    f"{col} should be datetime64[ns] type but got {X[col].dtype}"
+                    f"{self.classname()}: {col} should be datetime64[ns] type but got {X[col].dtype}"
                 )
 
         if not (X[self.columns[0]] <= X[self.columns[2]]).all():
 
             warnings.warn(
-                f"not all {self.columns[2]} are greater than or equal to {self.columns[0]}"
+                f"{self.classname()}: not all {self.columns[2]} are greater than or equal to {self.columns[0]}"
             )
 
         if self.lower_inclusive:

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -67,7 +67,9 @@ class ArbitraryImputer(BaseImputer):
 
         if columns is None:
 
-            raise ValueError(f"{self.classname()}: columns must be specified in init for ArbitraryImputer")
+            raise ValueError(
+                f"{self.classname()}: columns must be specified in init for ArbitraryImputer"
+            )
 
         super().__init__(columns=columns, **kwargs)
 

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -67,7 +67,7 @@ class ArbitraryImputer(BaseImputer):
 
         if columns is None:
 
-            raise ValueError("columns must be specified in init for ArbitraryImputer")
+            raise ValueError(f"{self.classname()}: columns must be specified in init for ArbitraryImputer")
 
         super().__init__(columns=columns, **kwargs)
 
@@ -78,7 +78,7 @@ class ArbitraryImputer(BaseImputer):
         ):
 
             raise ValueError(
-                "impute_value should be a single value (int, float or str)"
+                f"{self.classname()}: impute_value should be a single value (int, float or str)"
             )
 
         self.impute_values_ = {}
@@ -301,7 +301,7 @@ class NearestMeanResponseImputer(BaseImputer):
 
         if n_nulls > 0:
 
-            raise ValueError(f"y has {n_nulls} null values")
+            raise ValueError(f"{self.classname()}: y has {n_nulls} null values")
 
         self.impute_values_ = {}
 
@@ -315,7 +315,7 @@ class NearestMeanResponseImputer(BaseImputer):
             if c_nulls.sum() == 0:
 
                 raise ValueError(
-                    f"Column {c} has no missing values, cannot use this transformer."
+                    f"{self.classname()}: Column {c} has no missing values, cannot use this transformer."
                 )
 
             else:

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -37,21 +37,21 @@ class BaseMappingTransformer(BaseTransformer):
 
             if not len(mappings) > 0:
 
-                raise ValueError("mappings has no values")
+                raise ValueError(f"{self.classname()}: mappings has no values")
 
             for j in mappings.values():
 
                 if not isinstance(j, dict):
 
                     raise ValueError(
-                        "values in mappings dictionary should be dictionaries"
+                        f"{self.classname()}: values in mappings dictionary should be dictionaries"
                     )
 
             self.mappings = mappings
 
         else:
 
-            raise ValueError("mappings must be a dictionary")
+            raise ValueError(f"{self.classname()}: mappings must be a dictionary")
 
         columns = list(mappings.keys())
 
@@ -157,7 +157,7 @@ class MappingTransformer(BaseMappingTransformer, BaseMappingTransformMixin):
             else:
 
                 raise TypeError(
-                    f"each item in mappings should be a dict but got type {type(v)} for key {k}"
+                    f"{self.classname()}: each item in mappings should be a dict but got type {type(v)} for key {k}"
                 )
 
         BaseMappingTransformer.__init__(self, mappings=mappings, **kwargs)
@@ -226,14 +226,14 @@ class CrossColumnMappingTransformer(BaseMappingTransformer):
 
         if not isinstance(adjust_column, str):
 
-            raise TypeError("adjust_column should be a string")
+            raise TypeError(f"{self.classname()}: adjust_column should be a string")
 
         if len(mappings) > 1:
 
             if not isinstance(mappings, OrderedDict):
 
                 raise TypeError(
-                    "mappings should be an ordered dict for 'replace' mappings using multiple columns"
+                    f"{self.classname()}: mappings should be an ordered dict for 'replace' mappings using multiple columns"
                 )
 
         self.adjust_column = adjust_column
@@ -259,7 +259,7 @@ class CrossColumnMappingTransformer(BaseMappingTransformer):
 
         if self.adjust_column not in X.columns.values:
 
-            raise ValueError("variable " + self.adjust_column + " is not in X")
+            raise ValueError(f"{self.classname()}: variable {self.adjust_column} is not in X")
 
         for i in self.columns:
 
@@ -311,7 +311,7 @@ class CrossColumnMultiplyTransformer(BaseMappingTransformer):
 
         if not isinstance(adjust_column, str):
 
-            raise TypeError("adjust_column should be a string")
+            raise TypeError(f"{self.classname()}: adjust_column should be a string")
 
         for j in mappings.values():
 
@@ -319,7 +319,7 @@ class CrossColumnMultiplyTransformer(BaseMappingTransformer):
 
                 if type(k) not in [int, float]:
 
-                    raise TypeError("mapping values must be numeric")
+                    raise TypeError(f"{self.classname()}: mapping values must be numeric")
 
         self.adjust_column = adjust_column
 
@@ -344,12 +344,12 @@ class CrossColumnMultiplyTransformer(BaseMappingTransformer):
 
         if self.adjust_column not in X.columns.values:
 
-            raise ValueError("variable " + self.adjust_column + " is not in X")
+            raise ValueError(f"{self.classname()}: variable {self.adjust_column} is not in X")
 
         if not pd.api.types.is_numeric_dtype(X[self.adjust_column]):
 
             raise TypeError(
-                "variable " + self.adjust_column + " must have numeric dtype."
+                f"{self.classname()}: variable {self.adjust_column} must have numeric dtype."
             )
 
         for i in self.columns:
@@ -404,7 +404,7 @@ class CrossColumnAddTransformer(BaseMappingTransformer):
 
         if not isinstance(adjust_column, str):
 
-            raise TypeError("adjust_column should be a string")
+            raise TypeError(f"{self.classname()}: adjust_column should be a string")
 
         for j in mappings.values():
 
@@ -412,7 +412,7 @@ class CrossColumnAddTransformer(BaseMappingTransformer):
 
                 if type(k) not in [int, float]:
 
-                    raise TypeError("mapping values must be numeric")
+                    raise TypeError(f"{self.classname()}: mapping values must be numeric")
 
         self.adjust_column = adjust_column
 
@@ -437,12 +437,12 @@ class CrossColumnAddTransformer(BaseMappingTransformer):
 
         if self.adjust_column not in X.columns.values:
 
-            raise ValueError("variable " + self.adjust_column + " is not in X")
+            raise ValueError(f"{self.classname()}: variable " + self.adjust_column + " is not in X")
 
         if not pd.api.types.is_numeric_dtype(X[self.adjust_column]):
 
             raise TypeError(
-                "variable " + self.adjust_column + " must have numeric dtype."
+                f"{self.classname()}: variable " + self.adjust_column + " must have numeric dtype."
             )
 
         for i in self.columns:

--- a/tubular/mapping.py
+++ b/tubular/mapping.py
@@ -259,7 +259,9 @@ class CrossColumnMappingTransformer(BaseMappingTransformer):
 
         if self.adjust_column not in X.columns.values:
 
-            raise ValueError(f"{self.classname()}: variable {self.adjust_column} is not in X")
+            raise ValueError(
+                f"{self.classname()}: variable {self.adjust_column} is not in X"
+            )
 
         for i in self.columns:
 
@@ -319,7 +321,9 @@ class CrossColumnMultiplyTransformer(BaseMappingTransformer):
 
                 if type(k) not in [int, float]:
 
-                    raise TypeError(f"{self.classname()}: mapping values must be numeric")
+                    raise TypeError(
+                        f"{self.classname()}: mapping values must be numeric"
+                    )
 
         self.adjust_column = adjust_column
 
@@ -344,7 +348,9 @@ class CrossColumnMultiplyTransformer(BaseMappingTransformer):
 
         if self.adjust_column not in X.columns.values:
 
-            raise ValueError(f"{self.classname()}: variable {self.adjust_column} is not in X")
+            raise ValueError(
+                f"{self.classname()}: variable {self.adjust_column} is not in X"
+            )
 
         if not pd.api.types.is_numeric_dtype(X[self.adjust_column]):
 
@@ -412,7 +418,9 @@ class CrossColumnAddTransformer(BaseMappingTransformer):
 
                 if type(k) not in [int, float]:
 
-                    raise TypeError(f"{self.classname()}: mapping values must be numeric")
+                    raise TypeError(
+                        f"{self.classname()}: mapping values must be numeric"
+                    )
 
         self.adjust_column = adjust_column
 
@@ -437,12 +445,16 @@ class CrossColumnAddTransformer(BaseMappingTransformer):
 
         if self.adjust_column not in X.columns.values:
 
-            raise ValueError(f"{self.classname()}: variable " + self.adjust_column + " is not in X")
+            raise ValueError(
+                f"{self.classname()}: variable " + self.adjust_column + " is not in X"
+            )
 
         if not pd.api.types.is_numeric_dtype(X[self.adjust_column]):
 
             raise TypeError(
-                f"{self.classname()}: variable " + self.adjust_column + " must have numeric dtype."
+                f"{self.classname()}: variable "
+                + self.adjust_column
+                + " must have numeric dtype."
             )
 
         for i in self.columns:

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -40,7 +40,9 @@ class BaseNominalTransformer(BaseTransformer):
 
             if not len(columns) > 0:
 
-                raise ValueError(f"{self.classname()}: no object or category columns in X")
+                raise ValueError(
+                    f"{self.classname()}: no object or category columns in X"
+                )
 
             self.columns = columns
 
@@ -302,7 +304,9 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
 
             if not isinstance(weight, str):
 
-                raise ValueError(f"{self.classname()}: weight should be a single column (str)")
+                raise ValueError(
+                    f"{self.classname()}: weight should be a single column (str)"
+                )
 
         self.weight = weight
 
@@ -529,13 +533,17 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
 
             if self.weights_column not in X.columns.values:
 
-                raise ValueError(f"{self.classname()}: weights column {self.weights_column} not in X")
+                raise ValueError(
+                    f"{self.classname()}: weights column {self.weights_column} not in X"
+                )
 
         response_null_count = y.isnull().sum()
 
         if response_null_count > 0:
 
-            raise ValueError(f"{self.classname()}: y has {response_null_count} null values")
+            raise ValueError(
+                f"{self.classname()}: y has {response_null_count} null values"
+            )
 
         X_y = self._combine_X_y(X, y)
         response_column = "_temporary_response"
@@ -653,13 +661,17 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
             if self.weights_column not in X.columns.values:
 
-                raise ValueError(f"{self.classname()}: weights column {self.weights_column} not in X")
+                raise ValueError(
+                    f"{self.classname()}: weights column {self.weights_column} not in X"
+                )
 
         response_null_count = y.isnull().sum()
 
         if response_null_count > 0:
 
-            raise ValueError(f"{self.classname()}: y has {response_null_count} null values")
+            raise ValueError(
+                f"{self.classname()}: y has {response_null_count} null values"
+            )
 
         X_y = self._combine_X_y(X, y)
         response_column = "_temporary_response"
@@ -814,7 +826,10 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
 
             if X[c].isnull().sum() > 0:
 
-                raise ValueError(f"{self.classname()}: column %s has nulls - replace before proceeding" % c)
+                raise ValueError(
+                    f"{self.classname()}: column %s has nulls - replace before proceeding"
+                    % c
+                )
 
         # Check each field has less than 100 categories/levels
         for c in self.columns:
@@ -859,7 +874,10 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
 
             if X[c].isnull().sum() > 0:
 
-                raise ValueError(f"{self.classname()}: column %s has nulls - replace before proceeding" % c)
+                raise ValueError(
+                    f"{self.classname()}: column %s has nulls - replace before proceeding"
+                    % c
+                )
 
         X = BaseNominalTransformer.transform(self, X)
 
@@ -900,7 +918,8 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
                 if len(unseen_levels) > 0:
 
                     warnings.warn(
-                        f"{self.classname()}: column %s has unseen categories: %s" % (c, unseen_levels)
+                        f"{self.classname()}: column %s has unseen categories: %s"
+                        % (c, unseen_levels)
                     )
 
         # Drop original columns

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -40,7 +40,7 @@ class BaseNominalTransformer(BaseTransformer):
 
             if not len(columns) > 0:
 
-                raise ValueError("no object or category columns in X")
+                raise ValueError(f"{self.classname()}: no object or category columns in X")
 
             self.columns = columns
 
@@ -69,7 +69,7 @@ class BaseNominalTransformer(BaseTransformer):
             if mappable_rows < X.shape[0]:
 
                 raise ValueError(
-                    f"nulls would be introduced into column {c} from levels not present in mapping"
+                    f"{self.classname()}: nulls would be introduced into column {c} from levels not present in mapping"
                 )
 
 
@@ -113,7 +113,7 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
 
         if not isinstance(start_encoding, int):
 
-            raise ValueError("start_encoding should be an integer")
+            raise ValueError(f"{self.classname()}: start_encoding should be an integer")
 
         self.start_encoding = start_encoding
 
@@ -205,7 +205,7 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
             if (X.shape[0] - mappable_rows) > 0:
 
                 raise ValueError(
-                    "nulls introduced from levels not present in mapping for column: "
+                    f"{self.classname()}: nulls introduced from levels not present in mapping for column: "
                     + c
                 )
 
@@ -290,11 +290,11 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
 
         if not isinstance(cut_off_percent, float):
 
-            raise ValueError("cut_off_percent must be a float")
+            raise ValueError(f"{self.classname()}: cut_off_percent must be a float")
 
         if not ((cut_off_percent > 0) & (cut_off_percent < 1)):
 
-            raise ValueError("cut_off_percent must be > 0 and < 1")
+            raise ValueError(f"{self.classname()}: cut_off_percent must be > 0 and < 1")
 
         self.cut_off_percent = cut_off_percent
 
@@ -302,7 +302,7 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
 
             if not isinstance(weight, str):
 
-                raise ValueError("weight should be a single column (str)")
+                raise ValueError(f"{self.classname()}: weight should be a single column (str)")
 
         self.weight = weight
 
@@ -310,7 +310,7 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
 
         if not isinstance(record_rare_levels, bool):
 
-            raise ValueError("record_rare_levels must be a bool")
+            raise ValueError(f"{self.classname()}: record_rare_levels must be a bool")
 
         self.record_rare_levels = record_rare_levels
 
@@ -342,14 +342,14 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
                 if pd.Series(self.rare_level_name).dtype != X[c].dtypes:
 
                     raise ValueError(
-                        "rare_level_name must be of the same type of the columns"
+                        f"{self.classname()}: rare_level_name must be of the same type of the columns"
                     )
 
         if self.weight is not None:
 
             if self.weight not in X.columns.values:
 
-                raise ValueError("weight " + self.weight + " not in X")
+                raise ValueError(f"{self.classname()}: weight {self.weight} not in X")
 
         self.mapping_ = {}
 
@@ -498,7 +498,7 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
 
             if type(weights_column) is not str:
 
-                raise TypeError("weights_column should be a str")
+                raise TypeError(f"{self.classname()}: weights_column should be a str")
 
         self.weights_column = weights_column
 
@@ -529,13 +529,13 @@ class MeanResponseTransformer(BaseNominalTransformer, BaseMappingTransformMixin)
 
             if self.weights_column not in X.columns.values:
 
-                raise ValueError(f"weights column {self.weights_column} not in X")
+                raise ValueError(f"{self.classname()}: weights column {self.weights_column} not in X")
 
         response_null_count = y.isnull().sum()
 
         if response_null_count > 0:
 
-            raise ValueError(f"y has {response_null_count} null values")
+            raise ValueError(f"{self.classname()}: y has {response_null_count} null values")
 
         X_y = self._combine_X_y(X, y)
         response_column = "_temporary_response"
@@ -622,7 +622,7 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
             if type(weights_column) is not str:
 
-                raise TypeError("weights_column should be a str")
+                raise TypeError(f"{self.classname()}: weights_column should be a str")
 
         self.weights_column = weights_column
 
@@ -653,13 +653,13 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
 
             if self.weights_column not in X.columns.values:
 
-                raise ValueError(f"weights column {self.weights_column} not in X")
+                raise ValueError(f"{self.classname()}: weights column {self.weights_column} not in X")
 
         response_null_count = y.isnull().sum()
 
         if response_null_count > 0:
 
-            raise ValueError(f"y has {response_null_count} null values")
+            raise ValueError(f"{self.classname()}: y has {response_null_count} null values")
 
         X_y = self._combine_X_y(X, y)
         response_column = "_temporary_response"
@@ -814,7 +814,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
 
             if X[c].isnull().sum() > 0:
 
-                raise ValueError("column %s has nulls - replace before proceeding" % c)
+                raise ValueError(f"{self.classname()}: column %s has nulls - replace before proceeding" % c)
 
         # Check each field has less than 100 categories/levels
         for c in self.columns:
@@ -824,7 +824,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
             if len(levels) > 100:
 
                 raise ValueError(
-                    "column %s has over 100 unique values - consider another type of encoding"
+                    f"{self.classname()}: column %s has over 100 unique values - consider another type of encoding"
                     % c
                 )
 
@@ -859,7 +859,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
 
             if X[c].isnull().sum() > 0:
 
-                raise ValueError("column %s has nulls - replace before proceeding" % c)
+                raise ValueError(f"{self.classname()}: column %s has nulls - replace before proceeding" % c)
 
         X = BaseNominalTransformer.transform(self, X)
 
@@ -900,7 +900,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
                 if len(unseen_levels) > 0:
 
                     warnings.warn(
-                        "column %s has unseen categories: %s" % (c, unseen_levels)
+                        f"{self.classname()}: column %s has unseen categories: %s" % (c, unseen_levels)
                     )
 
         # Drop original columns

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -66,7 +66,9 @@ class LogTransformer(BaseTransformer):
             if not isinstance(base, (int, float)):
                 raise ValueError(f"{self.classname()}: base should be numeric or None")
             if not base > 0:
-                raise ValueError(f"{self.classname()}: base should be strictly positive")
+                raise ValueError(
+                    f"{self.classname()}: base should be strictly positive"
+                )
 
         self.base = base
         self.add_1 = add_1
@@ -276,7 +278,9 @@ class ScalingTransformer(BaseTransformer):
 
         if scaler_type not in allowed_scaler_values:
 
-            raise ValueError(f"{self.classname()}: scaler_type should be one of; {allowed_scaler_values}")
+            raise ValueError(
+                f"{self.classname()}: scaler_type should be one of; {allowed_scaler_values}"
+            )
 
         if scaler_type == "min_max":
 
@@ -435,7 +439,9 @@ class InteractionTransformer(BaseTransformer):
             )
         if type(max_degree) is int:
             if min_degree > max_degree:
-                raise ValueError(f"{self.classname()}: max_degree must be equal or greater than min_degree")
+                raise ValueError(
+                    f"{self.classname()}: max_degree must be equal or greater than min_degree"
+                )
             else:
                 self.max_degree = max_degree
             if max_degree > len(columns):

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -64,9 +64,9 @@ class LogTransformer(BaseTransformer):
 
         if base is not None:
             if not isinstance(base, (int, float)):
-                raise ValueError("base should be numeric or None")
+                raise ValueError(f"{self.classname()}: base should be numeric or None")
             if not base > 0:
-                raise ValueError("base should be strictly positive")
+                raise ValueError(f"{self.classname()}: base should be strictly positive")
 
         self.base = base
         self.add_1 = add_1
@@ -105,7 +105,7 @@ class LogTransformer(BaseTransformer):
             )
 
             raise TypeError(
-                f"The following columns are not numeric in X; {non_numeric_columns}"
+                f"{self.classname()}: The following columns are not numeric in X; {non_numeric_columns}"
             )
 
         new_column_names = [f"{column}_{self.suffix}" for column in self.columns]
@@ -115,7 +115,7 @@ class LogTransformer(BaseTransformer):
             if (X[self.columns] <= -1).sum().sum() > 0:
 
                 raise ValueError(
-                    "values less than or equal to 0 in columns (after adding 1), make greater than 0 before using transform"
+                    f"{self.classname()}: values less than or equal to 0 in columns (after adding 1), make greater than 0 before using transform"
                 )
 
             if self.base is None:
@@ -131,7 +131,7 @@ class LogTransformer(BaseTransformer):
             if (X[self.columns] <= 0).sum().sum() > 0:
 
                 raise ValueError(
-                    "values less than or equal to 0 in columns, make greater than 0 before using transform"
+                    f"{self.classname()}: values less than or equal to 0 in columns, make greater than 0 before using transform"
                 )
 
             if self.base is None:
@@ -176,17 +176,17 @@ class CutTransformer(BaseTransformer):
         if not type(column) is str:
 
             raise TypeError(
-                "column arg (name of column) should be a single str giving the column to discretise"
+                f"{self.classname()}: column arg (name of column) should be a single str giving the column to discretise"
             )
 
         if not type(new_column_name) is str:
 
-            raise TypeError("new_column_name must be a str")
+            raise TypeError(f"{self.classname()}: new_column_name must be a str")
 
         if not type(cut_kwargs) is dict:
 
             raise TypeError(
-                f"cut_kwargs should be a dict but got type {type(cut_kwargs)}"
+                f"{self.classname()}: cut_kwargs should be a dict but got type {type(cut_kwargs)}"
             )
 
         else:
@@ -196,7 +196,7 @@ class CutTransformer(BaseTransformer):
                 if not type(k) is str:
 
                     raise TypeError(
-                        f"unexpected type ({type(k)}) for cut_kwargs key in position {i}, must be str"
+                        f"{self.classname()}: unexpected type ({type(k)}) for cut_kwargs key in position {i}, must be str"
                     )
 
         self.cut_kwargs = cut_kwargs
@@ -223,7 +223,7 @@ class CutTransformer(BaseTransformer):
         if not pd.api.types.is_numeric_dtype(X[self.columns[0]]):
 
             raise TypeError(
-                f"{self.columns[0]} should be a numeric dtype but got {X[self.columns[0]].dtype}"
+                f"{self.classname()}: {self.columns[0]} should be a numeric dtype but got {X[self.columns[0]].dtype}"
             )
 
         X[self.new_column_name] = pd.cut(X[self.columns[0]], **self.cut_kwargs)
@@ -259,7 +259,7 @@ class ScalingTransformer(BaseTransformer):
         if not type(scaler_kwargs) is dict:
 
             raise TypeError(
-                f"scaler_kwargs should be a dict but got type {type(scaler_kwargs)}"
+                f"{self.classname()}: scaler_kwargs should be a dict but got type {type(scaler_kwargs)}"
             )
 
         else:
@@ -269,14 +269,14 @@ class ScalingTransformer(BaseTransformer):
                 if not type(k) is str:
 
                     raise TypeError(
-                        f"unexpected type ({type(k)}) for scaler_kwargs key in position {i}, must be str"
+                        f"{self.classname()}: unexpected type ({type(k)}) for scaler_kwargs key in position {i}, must be str"
                     )
 
         allowed_scaler_values = ["min_max", "max_abs", "standard"]
 
         if scaler_type not in allowed_scaler_values:
 
-            raise ValueError(f"scaler_type should be one of; {allowed_scaler_values}")
+            raise ValueError(f"{self.classname()}: scaler_type should be one of; {allowed_scaler_values}")
 
         if scaler_type == "min_max":
 
@@ -318,7 +318,7 @@ class ScalingTransformer(BaseTransformer):
             )
 
             raise TypeError(
-                f"The following columns are not numeric in X; {non_numeric_columns}"
+                f"{self.classname()}: The following columns are not numeric in X; {non_numeric_columns}"
             )
 
         return X
@@ -419,34 +419,34 @@ class InteractionTransformer(BaseTransformer):
 
         if len(columns) < 2:
             raise ValueError(
-                f"number of columns must be equal or greater than 2, got {str(len(columns))} column."
+                f"{self.classname()}: number of columns must be equal or greater than 2, got {str(len(columns))} column."
             )
 
         if type(min_degree) is int:
             if min_degree < 2:
                 raise ValueError(
-                    f"min_degree must be equal or greater than 2, got {str(min_degree)}"
+                    f"{self.classname()}: min_degree must be equal or greater than 2, got {str(min_degree)}"
                 )
             else:
                 self.min_degree = min_degree
         else:
             raise TypeError(
-                f"unexpected type ({type(min_degree)}) for min_degree, must be int"
+                f"{self.classname()}: unexpected type ({type(min_degree)}) for min_degree, must be int"
             )
         if type(max_degree) is int:
             if min_degree > max_degree:
-                raise ValueError("max_degree must be equal or greater than min_degree")
+                raise ValueError(f"{self.classname()}: max_degree must be equal or greater than min_degree")
             else:
                 self.max_degree = max_degree
             if max_degree > len(columns):
                 raise ValueError(
-                    "max_degree must be equal or lower than number of columns"
+                    f"{self.classname()}: max_degree must be equal or lower than number of columns"
                 )
             else:
                 self.max_degree = max_degree
         else:
             raise TypeError(
-                f"unexpected type ({type(max_degree)}) for max_degree, must be int"
+                f"{self.classname()}: unexpected type ({type(max_degree)}) for max_degree, must be int"
             )
 
         self.nb_features_to_interact = len(self.columns)

--- a/tubular/strings.py
+++ b/tubular/strings.py
@@ -60,7 +60,7 @@ class SeriesStrMethodTransformer(BaseTransformer):
             if len(columns) > 1:
 
                 raise ValueError(
-                    f"columns arg should contain only 1 column name but got {len(columns)}"
+                    f"{self.classname()}: columns arg should contain only 1 column name but got {len(columns)}"
                 )
 
         super().__init__(columns=columns, **kwargs)
@@ -68,19 +68,19 @@ class SeriesStrMethodTransformer(BaseTransformer):
         if type(new_column_name) is not str:
 
             raise TypeError(
-                f"unexpected type ({type(new_column_name)}) for new_column_name, must be str"
+                f"{self.classname()}: unexpected type ({type(new_column_name)}) for new_column_name, must be str"
             )
 
         if type(pd_method_name) is not str:
 
             raise TypeError(
-                f"unexpected type ({type(pd_method_name)}) for pd_method_name, expecting str"
+                f"{self.classname()}: unexpected type ({type(pd_method_name)}) for pd_method_name, expecting str"
             )
 
         if type(pd_method_kwargs) is not dict:
 
             raise TypeError(
-                f"pd_method_kwargs should be a dict but got type {type(pd_method_kwargs)}"
+                f"{self.classname()}: pd_method_kwargs should be a dict but got type {type(pd_method_kwargs)}"
             )
 
         else:
@@ -90,7 +90,7 @@ class SeriesStrMethodTransformer(BaseTransformer):
                 if not type(k) is str:
 
                     raise TypeError(
-                        f"unexpected type ({type(k)}) for pd_method_kwargs key in position {i}, must be str"
+                        f"{self.classname()}: unexpected type ({type(k)}) for pd_method_kwargs key in position {i}, must be str"
                     )
 
         self.new_column_name = new_column_name
@@ -105,7 +105,7 @@ class SeriesStrMethodTransformer(BaseTransformer):
         except Exception as err:
 
             raise AttributeError(
-                f"""error accessing "str.{pd_method_name}" method on pd.Series object - pd_method_name should be a pd.Series.str method"""
+                f"""{self.classname()}: error accessing "str.{pd_method_name}" method on pd.Series object - pd_method_name should be a pd.Series.str method"""
             ) from err
 
     def transform(self, X):


### PR DESCRIPTION
Added classname() method to BaseTransformer
Prefixed all errors with classname call for easier debugging
