### PR TITLE
caps sklearn version at sklearn < 1.2  

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,13 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
+0.3.6 (unreleased)
+------------------
+
+Changed
+^^^^^^^
+- added sklearn < 1.2 dependency `#86 <https://github.com/lvgig/tubular/pull/86>`_
+
 0.3.5 (2023-04-26)
 ------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 test-aide>=0.1.0
 pandas>=1.0.0, <2.0.0
-scikit-learn>=0.22
+scikit-learn>=0.22, <1.2
 pytest>=5.4.1
 pytest-mock>=3.5.1
 pytest-cov>=2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pandas>=1.0.0, <2.0.0
-scikit-learn>=0.22
+scikit-learn>=0.22, <1.2


### PR DESCRIPTION
caps sklearn version at sklearn < 1.2   when Boston dataset used in some tubular tests was removed.  This is a temporary fix until those tests can be updated.