### PR TITLE
Updating files to allow sklearn version >1.20, unpin req

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/flake8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,15 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
+0.3.7 (2023-06-23)
+------------------
+
+Changed
+^^^^^^^
+- minor change to `GroupRareLevelsTransformer` `test_super_transform_called` test to align with other cases
+- removed pin of scikit-learn version to <1.20
+- update `black` version in pre-commit-config
+
 0.3.6 (2023-05-24)
 ------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 test-aide>=0.1.0
 pandas>=1.0.0, <2.0.0
-scikit-learn>=0.22, <1.2
+scikit-learn>=0.22
 pytest>=5.4.1
 pytest-mock>=3.5.1
 pytest-cov>=2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pandas>=1.0.0, <2.0.0
-scikit-learn>=0.22, <1.2
+scikit-learn>=0.22

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -342,11 +342,19 @@ class TestTransform(object):
 
         x.fit(df)
 
-        expected_call_args = {0: {"args": (d.create_df_5(),), "kwargs": {}}}
+        expected_call_args = {
+            0: {
+                "args": (
+                    x,
+                    d.create_df_5(),
+                ),
+                "kwargs": {},
+            }
+        }
 
         with ta.functions.assert_function_call(
             mocker,
-            tubular.base.BaseTransformer,
+            tubular.nominal.BaseNominalTransformer,
             "transform",
             expected_call_args,
             return_value=d.create_df_5(),

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -12,10 +12,10 @@ from tubular.mapping import BaseMappingTransformMixin
 
 
 class BaseNominalTransformer(BaseTransformer):
-    """Base nominal transformer designed inherrited from for nominal transformers.
+    """Base Transformer extension for nominal transformers.
 
     Contains columns_set_or_check method which overrides the columns_set_or_check method in BaseTransformer if given
-    primacy in inheritance. The difference being that NominalColumnSetOrCheckMixin's columns_set_or_check only selects
+    primacy in inheritance. The difference being that BaseNominalTransformer's columns_set_or_check only selects
     object and categorical columns from X, if the columns attribute is not set by the user.
     """
 
@@ -436,7 +436,7 @@ class GroupRareLevelsTransformer(BaseNominalTransformer):
 
         """
 
-        X = super().transform(X)
+        X = BaseNominalTransformer.transform(self, X)
 
         self.check_is_fitted(["mapping_"])
 


### PR DESCRIPTION
- minor changes to GroupRareLevelsTransformer to ensure all recent versions of sklearn can be used
- sklearn pin removed from reqs
- update black version in precommit to match that in requirements-dev.txt