### PR TITLE
Feature/release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-on: workflow_dispatch
+on:
+  release:
+    types: [published]
     
 jobs:
   pypi-publish:
@@ -22,7 +24,3 @@ jobs:
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-    - name: Github Release  
-      uses: softprops/action-gh-release@v1  
-      with:  
-        files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,7 @@
-
+on:
+  release:
+    types: [published]
+    
 jobs:
   pypi-publish:
     name: Upload release to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.x"
     - name: "Build Package"
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-      - name: "Build Package"
-        run: |
-          python setup.py sdist bdist_wheel
-          pip install twine 
-          twine check dist/* 
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.8"
+    - name: "Build Package"
+      run: |
+        python setup.py sdist bdist_wheel
+        pip install twine 
+        twine check dist/* 
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,9 @@ jobs:
           python-version: "3.8"
       - name: "Build Package"
         run: |
-        python setup.py sdist bdist_wheel
-        pip install twine 
-        twine check dist/* 
+          python setup.py sdist bdist_wheel
+          pip install twine 
+          twine check dist/* 
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+
+jobs:
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tubular
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+    steps:
+    - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+      - name: "Build Package"
+        run: |
+        python setup.py sdist bdist_wheel
+        pip install twine 
+        twine check dist/* 
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
     - name: Build Package
       run: |
         python setup.py sdist bdist_wheel
-        pip install twine 
-        twine check dist/* 
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     - uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+    - name: Install dependencies
+      run: pip install wheel
     - name: "Build Package"
       run: |
         python setup.py sdist bdist_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,4 @@
-on:
-  release:
-    types: [published]
+on: workflow_dispatch
     
 jobs:
   pypi-publish:
@@ -24,3 +22,7 @@ jobs:
 
     - name: Publish package distributions to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+    - name: Github Release  
+      uses: softprops/action-gh-release@v1  
+      with:  
+        files: dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: "3.x"
     - name: Install dependencies
       run: pip install wheel
-    - name: "Build Package"
+    - name: Build Package
       run: |
         python setup.py sdist bdist_wheel
         pip install twine 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"


### PR DESCRIPTION
Pypi now requires 2FA and as such publishing new releases needs either an [api token](uhttps://pypi.org/help/#apitoken) or setting a ['trusted publisher' ](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) and a release workflow.  Uploading dist files using twine and entering username/password is no longer supported.

I have added a release pipeline to the .github folder. which is set up to use Trusted publishers.  this could be changed to use an API token instead by adding:

`      with:
        user: __token__
        password: ${{ secrets.PYPI_API_TOKEN }}`
        
Note however that the pypi documentation strongly recommends using trusted publishers over [api token](uhttps://pypi.org/help/#apitoken)

The pipeline is triggered on publication and uses the gh-action-pypi-publish git hub action.  The script is an amalgam of the [example scripts there](https://github.com/pypa/gh-action-pypi-publish) and the default publish to pypi action from the actions pane.