### PR TITLE
Feature/nominal dtype checks in transform

### DIFF
--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1023,6 +1023,19 @@ class TestTransform:
         ):
             x.transform(df)
 
+    def test_not_dataframe_error_raised(self):
+
+        df = d.create_MeanResponseTransformer_test_df()
+
+        x = MeanResponseTransformer(columns="b")
+        x.fit(df, df["a"])
+
+        with pytest.raises(
+            TypeError,
+            match=f"{x.classname()}: X should be a pd.DataFrame",
+        ):
+            x.transform(X=[1, 2, 3, 4, 5, 6])
+
     def test_super_transform_called(self, mocker):
         """Test that BaseTransformer.transform called."""
         df = d.create_MeanResponseTransformer_test_df()

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -178,6 +178,19 @@ class TestTransform:
         ):
             x.transform(df)
 
+    def test_not_dataframe_error_raised(self):
+
+        df = d.create_df_1()
+
+        x = NominalToIntegerTransformer(columns=["a", "b"])
+        x.fit(df, df["a"])
+
+        with pytest.raises(
+            TypeError,
+            match=f"{x.classname()}: X should be a pd.DataFrame",
+        ):
+            x.transform(X=[1, 2, 3, 4, 5, 6])
+
     def test_super_transform_called(self, mocker):
         """Test that BaseTransformer.transform called."""
         df = d.create_df_1()

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -229,6 +229,19 @@ class TestTransform:
         ):
             x.transform(df)
 
+    def test_not_dataframe_error_raised(self):
+
+        df = d.create_OrdinalEncoderTransformer_test_df()
+
+        x = OrdinalEncoderTransformer(columns="b")
+        x.fit(df, df["a"])
+
+        with pytest.raises(
+            TypeError,
+            match=f"{x.classname()}: X should be a pd.DataFrame",
+        ):
+            x.transform(X=[1, 2, 3, 4, 5, 6])
+
     def test_super_transform_called(self, mocker):
         """Test that BaseMappingTransformMixin.transform called."""
         df = d.create_OrdinalEncoderTransformer_test_df()

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1006,6 +1006,8 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
             Transformed data with levels mapped to ordinal encoded values for categorical variables.
 
         """
+        X = super().transform(X)
+
         self.check_mappable_rows(X)
 
         return BaseMappingTransformMixin.transform(self, X)

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -833,6 +833,8 @@ class MeanResponseTransformer(BaseNominalTransformer):
             Transformed input X with levels mapped accoriding to mappings dict.
 
         """
+        X = super().transform(X)
+
         if self.level:
             for response_level in self.response_levels:
                 for column in self.columns:
@@ -847,13 +849,11 @@ class MeanResponseTransformer(BaseNominalTransformer):
             for c in self.columns:
                 # finding rows with values not in the keys of mappings dictionary
                 unseen_indices[c] = X[~X[c].isin(self.mappings[c].keys())].index
-            X = super().transform(X)
             X = self.map_imputation_values(X)
             for c in self.columns:
                 X.loc[unseen_indices[c], c] = self.unseen_levels_encoding_dict[c]
         else:
             self.check_mappable_rows(X)
-            X = super().transform(X)
             X = self.map_imputation_values(X)
 
         if self.level:

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -158,6 +158,8 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
             Transformed input X with levels mapped accoriding to mappings dict.
 
         """
+        X = super().transform(X)
+
         self.check_mappable_rows(X)
 
         return BaseMappingTransformMixin.transform(self, X)


### PR DESCRIPTION
Addresses issue https://github.com/lvgig/tubular/issues/145 in part. I was unable to replicate the error I found in the generic testing where the `fit` method did not raise an appropriate error for X  not being a `pandas.DataFrame object`. 

This bug definitely exists for the `transform` method so I have fixed that - all it required was adding or moving a call to `BaseTransformer.transform`. This was always getting called, but always after the `check_mappable_rows` method inherited from `BaseNominalTransformer`, which was making checks that assumed a dataframe. This is a good example of an implementation test (super transform call) not testing for the behaviour we want (error if X not pd dataframe). I have now added a test for this behaviour (copied from BaseTransformer test suite).

The issue still mentions the possibility of adding nominal type checks (maybe with a warning) for  nominal transformers. I think probably best to get the bug fix in, close the issue and open a new issue for this feature.