### PR TITLE
build pipeline run on schedule

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -8,6 +8,9 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '30 7 * * 1' # 7:30 on monday morning
 
 jobs:
   build:


### PR DESCRIPTION
Update python-package.yml to trigger build pipeline on Monday morning at 7:30.  Documentation [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule)

We could go more or less frequent than this but I feel weekly runs should be sufficient to catch issues with unpinned package versions etc in a timeframe where action can be taken quickly.  Daily seems excessive but I'm happy to be convinced otherwise.