### PR TITLE
Feature/update pre commit

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Format with ruff
       if: always()
       run: |
-        ruff format --diff
+        ruff format . --diff
 
     - name: Test with pytest
       if: always()

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,13 +27,7 @@ jobs:
     - name: Lint with ruff
       uses: chartboost/ruff-action@v1
       with:
-        version: 0.0.275
-
-    - name: Lint with black
-      if: always()
-      run: |
-        black --version
-        black --check .
+        version: 0.1.6
 
     - name: Test with pytest
       if: always()

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,6 +29,11 @@ jobs:
       with:
         version: 0.1.6
 
+    - name: Format with ruff
+      if: always()
+      run: |
+        ruff format --diff
+
     - name: Test with pytest
       if: always()
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,9 @@
 repos:
--   repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.0.275
-    hooks:
+ - repo: https://github.com/astral-sh/ruff-pre-commit
+   rev: v0.1.6
+   hooks:
     - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
--   repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-    - id: black
-      language_version: python3
-    - id: black-jupyter
-      name: black-jupyter
-      description:
-        "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
-      entry: black
-      language: python
-      minimum_pre_commit_version: 2.9.2
-      require_serial: true
-      types_or: [python, pyi, jupyter]
-      additional_dependencies: [".[jupyter]"]
-
+      args: ["--extend-select=S"]
+      types_or: [ python, pyi, jupyter ]
+    - id: ruff-format
+      types_or: [ python ]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -5,10 +5,11 @@ select = ["E", "F", "W", "I", "UP", "ASYNC", "YTT", "A", "COM", "C4", "T10", "EM
 "FA", "ISC", "PIE", "PYI", "Q", "RSE", "RET", "SLOT", "SIM", "TID", "TCH", "INT", 
 "PD", "PGH", "PLC", "PLE", "PLW", "FLY", "NPY", "PERF", "B", "DTZ", "ANN"]
 
-
-# ignore E501 - linelength limit (covered by black except in docstrings) 
+# E501 line length 
 # and PD901 - use of df variable name
-ignore = ["E501", "PD901", "ANN101"]
+# COM81, ISC001 recommended to ignore when using formatter 
+# E721 type comparison
+ignore = ["E501", "E721", "PD901", "COM81", "ISC001", "ANN101"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
@@ -36,3 +37,4 @@ target-version = "py38"
 [per-file-ignores]
 "__init__.py" = ["E402", "F401"]
 "tests/*" = ["ANN"]
+"**/{tests,docs,tools}/*" = ["S101"] # use of assert (S101)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
+Changed
+^^^^^^^
+- pre-commit to run with ruff v0.1.6 
+
 1.1.1 (2024-01-18)
 ------------------
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ pytest-cov>=2.10.1
 pre-commit==2.15.0 
 black[jupyter]==22.3.0
 bandit==1.7.0
-ruff==0.0.275
+ruff==0.1.6

--- a/tests/dates/test_DateTimeInfoExtractor.py
+++ b/tests/dates/test_DateTimeInfoExtractor.py
@@ -59,7 +59,7 @@ class TestExtractDatetimeInfoInit:
         x = DatetimeInfoExtractor(
             columns=["a"],
             include=["timeofmonth", "timeofday"],
-            datetime_mappings={"timeofday": {"am": range(0, 12), "pm": range(12, 24)}},
+            datetime_mappings={"timeofday": {"am": range(12), "pm": range(12, 24)}},
         )
 
         ta.classes.test_object_attributes(
@@ -68,7 +68,7 @@ class TestExtractDatetimeInfoInit:
                 "columns": ["a"],
                 "include": ["timeofmonth", "timeofday"],
                 "datetime_mappings": {
-                    "timeofday": {"am": range(0, 12), "pm": range(12, 24)},
+                    "timeofday": {"am": range(12), "pm": range(12, 24)},
                 },
             },
             msg="Attributes for ExtractDatetimeInfo set in init",

--- a/tests/dates/test_DatetimeSinusoidCalculator.py
+++ b/tests/dates/test_DatetimeSinusoidCalculator.py
@@ -63,9 +63,7 @@ class TestDatetimeSinusoidCalculatorInit:
         """Test that an exception is raised if units is not a str or a dict."""
         with pytest.raises(
             TypeError,
-            match="units must be a string or dict but got {}".format(
-                type(incorrect_type_units),
-            ),
+            match=f"units must be a string or dict but got {type(incorrect_type_units)}",
         ):
             DatetimeSinusoidCalculator(
                 "a",
@@ -197,9 +195,7 @@ class TestDatetimeSinusoidCalculatorInit:
 
         with pytest.raises(
             ValueError,
-            match='Invalid method {} supplied, should be "sin", "cos" or a list containing both'.format(
-                method,
-            ),
+            match=f'Invalid method {method} supplied, should be "sin", "cos" or a list containing both',
         ):
             DatetimeSinusoidCalculator(
                 "a",
@@ -224,10 +220,7 @@ class TestDatetimeSinusoidCalculatorInit:
         with pytest.raises(
             ValueError,
             match=re.escape(
-                "Invalid units {} supplied, should be in {}".format(
-                    units,
-                    valid_unit_list,
-                ),
+                f"Invalid units {units} supplied, should be in {valid_unit_list}",
             ),
         ):
             DatetimeSinusoidCalculator(

--- a/tests/misc/test_SetColumnDtype.py
+++ b/tests/misc/test_SetColumnDtype.py
@@ -35,7 +35,7 @@ class TestSetColumnDtypeInit:
 
     @pytest.mark.parametrize(
         "invalid_dtype",
-        ["STRING", "misc_invalid", "np.int", int()],
+        ["STRING", "misc_invalid", "np.int", 0],
     )
     def test_invalid_dtype_error(self, invalid_dtype):
         msg = f"SetColumnDtype: data type '{invalid_dtype}' not understood as a valid dtype"

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1024,7 +1024,6 @@ class TestTransform:
             x.transform(df)
 
     def test_not_dataframe_error_raised(self):
-
         df = d.create_MeanResponseTransformer_test_df()
 
         x = MeanResponseTransformer(columns="b")

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -179,7 +179,6 @@ class TestTransform:
             x.transform(df)
 
     def test_not_dataframe_error_raised(self):
-
         df = d.create_df_1()
 
         x = NominalToIntegerTransformer(columns=["a", "b"])

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -230,7 +230,6 @@ class TestTransform:
             x.transform(df)
 
     def test_not_dataframe_error_raised(self):
-
         df = d.create_OrdinalEncoderTransformer_test_df()
 
         x = OrdinalEncoderTransformer(columns="b")

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -63,8 +63,8 @@ class CappingTransformer(BaseTransformer):
 
     def __init__(
         self,
-        capping_values: dict[str, list[int | float | None]] | None = None,
-        quantiles: dict[str, list[int | float]] | None = None,
+        capping_values: dict[str, list[float | None]] | None = None,
+        quantiles: dict[str, list[float]] | None = None,
         weights_column: str | None = None,
         **kwargs: dict[str, bool],
     ) -> None:
@@ -104,7 +104,7 @@ class CappingTransformer(BaseTransformer):
 
     def check_capping_values_dict(
         self,
-        capping_values_dict: dict[str, list[int | float | None]],
+        capping_values_dict: dict[str, list[float | None]],
         dict_name: str,
     ) -> None:
         """Performs checks on a dictionary passed to ."""
@@ -196,7 +196,7 @@ class CappingTransformer(BaseTransformer):
         values: pd.Series | np.array,
         quantiles: list[float],
         sample_weight: pd.Series | np.array | None = None,
-    ) -> list[int | float]:
+    ) -> list[float]:
         """Method to call the weighted_quantile method and prepare the outputs.
 
         If there are no None values in the supplied quantiles then the outputs from weighted_quantile
@@ -246,7 +246,7 @@ class CappingTransformer(BaseTransformer):
         values: pd.Series | np.array,
         quantiles: list[float],
         sample_weight: pd.Series | np.array | None = None,
-    ) -> list[int | float]:
+    ) -> list[float]:
         """Method to calculate weighted quantiles.
 
         This method is adapted from the "Completely vectorized numpy solution" answer from user
@@ -456,8 +456,8 @@ class OutOfRangeNullTransformer(CappingTransformer):
 
     def __init__(
         self,
-        capping_values: dict[str, list[int | float | None]] | None = None,
-        quantiles: dict[str, list[int | float]] | None = None,
+        capping_values: dict[str, list[float | None]] | None = None,
+        quantiles: dict[str, list[float]] | None = None,
         weights_column: str | None = None,
         **kwargs: dict[str, bool],
     ) -> None:

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -116,7 +116,6 @@ class BaseDateTransformer(BaseTransformer):
         temp = X[self.columns].copy()
 
         for column_one_name, column_two_name in itertools.permutations(self.columns):
-
             temp = self._cast_non_matching_columns(
                 temp,
                 column_one_name,
@@ -178,7 +177,7 @@ class DateDiffLeapYearTransformer(BaseDateTransformer):
         column_upper: str,
         drop_cols: bool,
         new_column_name: str | None = None,
-        missing_replacement: int | float | str | None = None,
+        missing_replacement: float | str | None = None,
         **kwargs: dict[str, bool],
     ) -> None:
         if not isinstance(column_lower, str):
@@ -832,10 +831,7 @@ class DatetimeInfoExtractor(BaseDateTransformer):
         self,
         columns: str | list[str],
         include: str | list[str] | None = None,
-        datetime_mappings: dict[
-            str,
-        ]
-        | None = None,
+        datetime_mappings: dict[str,] | None = None,
         **kwargs: dict[str, bool],
     ) -> None:
         if include is None:
@@ -883,7 +879,7 @@ class DatetimeInfoExtractor(BaseDateTransformer):
             timeofday_mapping = self.datetime_mappings["timeofday"]
         elif "timeofday" in include:  # Choose default mapping
             timeofday_mapping = {
-                "night": range(0, 6),  # Midnight - 6am
+                "night": range(6),  # Midnight - 6am
                 "morning": range(6, 12),  # 6am - Noon
                 "afternoon": range(12, 18),  # Noon - 6pm
                 "evening": range(18, 24),  # 6pm - Midnight
@@ -893,7 +889,7 @@ class DatetimeInfoExtractor(BaseDateTransformer):
             timeofmonth_mapping = self.datetime_mappings["timeofmonth"]
         elif "timeofmonth" in include:  # Choose default mapping
             timeofmonth_mapping = {
-                "start": range(0, 11),
+                "start": range(11),
                 "middle": range(11, 21),
                 "end": range(21, 32),
             }
@@ -967,7 +963,7 @@ class DatetimeInfoExtractor(BaseDateTransformer):
         else:
             self.dayofweek_mapping = {}
 
-    def _map_values(self, value: int | float, interval: str) -> str:
+    def _map_values(self, value: float, interval: str) -> str:
         """Method to apply mappings for a specified interval ("timeofday", "timeofmonth", "timeofyear" or "dayofweek")
         from corresponding mapping attribute to a single value.
 
@@ -1107,7 +1103,7 @@ class DatetimeSinusoidCalculator(BaseDateTransformer):
         columns: str | list[str],
         method: str | list[str],
         units: str | dict,
-        period: int | float | dict = 2 * np.pi,
+        period: float | dict = 2 * np.pi,
     ) -> None:
         super().__init__(columns, copy=True)
 

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -62,7 +62,7 @@ class ArbitraryImputer(BaseImputer):
 
     def __init__(
         self,
-        impute_value: int | float | str,
+        impute_value: float | str,
         columns: str | list[str] | None = None,
         **kwargs: dict[str, bool],
     ) -> None:

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -560,7 +560,7 @@ class MeanResponseTransformer(BaseNominalTransformer):
         weights_column: str | None = None,
         prior: int = 0,
         level: str | list | None = None,
-        unseen_level_handling: str | int | float | None = None,
+        unseen_level_handling: str | float | None = None,
         **kwargs: dict[str, bool],
     ) -> None:
         if weights_column is not None and type(weights_column) is not str:

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -56,6 +56,7 @@ class LogTransformer(BaseTransformer):
         The suffix to add onto the end of column names for new columns.
 
     """
+
     def __init__(
         self,
         columns: str | list[str] | None,
@@ -283,7 +284,7 @@ class TwoColumnOperatorTransformer(DataFrameMethodTransformer):
         if pd_method_kwargs is None:
             pd_method_kwargs = {"axis": 0}
         else:
-            if "axis" in pd_method_kwargs:
+            if "axis" not in pd_method_kwargs:
                 msg = f'{self.classname()}: pd_method_kwargs must contain an entry "axis" set to 0 or 1'
                 raise ValueError(msg)
             if pd_method_kwargs["axis"] not in [0, 1]:

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -56,7 +56,6 @@ class LogTransformer(BaseTransformer):
         The suffix to add onto the end of column names for new columns.
 
     """
-
     def __init__(
         self,
         columns: str | list[str] | None,

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -271,7 +271,6 @@ class TwoColumnOperatorTransformer(DataFrameMethodTransformer):
         Dictionary of method kwargs to be passed to pandas.DataFrame method.
 
     """
-
     def __init__(
         self,
         pd_method_name: str,

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -56,6 +56,7 @@ class LogTransformer(BaseTransformer):
         The suffix to add onto the end of column names for new columns.
 
     """
+
     def __init__(
         self,
         columns: str | list[str] | None,
@@ -270,6 +271,7 @@ class TwoColumnOperatorTransformer(DataFrameMethodTransformer):
         Dictionary of method kwargs to be passed to pandas.DataFrame method.
 
     """
+
     def __init__(
         self,
         pd_method_name: str,

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -60,7 +60,7 @@ class LogTransformer(BaseTransformer):
     def __init__(
         self,
         columns: str | list[str] | None,
-        base: float | int | None = None,
+        base: float | None = None,
         add_1: bool = False,
         drop: bool = True,
         suffix: str = "log",
@@ -284,7 +284,7 @@ class TwoColumnOperatorTransformer(DataFrameMethodTransformer):
         if pd_method_kwargs is None:
             pd_method_kwargs = {"axis": 0}
         else:
-            if "axis" not in pd_method_kwargs.keys():
+            if "axis" in pd_method_kwargs:
                 msg = f'{self.classname()}: pd_method_kwargs must contain an entry "axis" set to 0 or 1'
                 raise ValueError(msg)
             if pd_method_kwargs["axis"] not in [0, 1]:


### PR DESCRIPTION
Updates pre commit to use the latest version of ruff and not black.

Had to add a few things to ignore in ruff.toml, generally I used the project template approach for guidance. The two I'm least sure about were the following (done in order to avoid having to manually edit loads of files):
- E501 line length - apparently 88 is the line length preferred by black but with this set it was suggesting editing a lot of lines in supposedly black approved code
- E721 - forces `isinstance()` over `is type()` etc

Fixed ruff's complaint about using `int | float`  instead of just `float`. Done in a specific revert so easy to revert if we don't like this.