### PR TITLE
Makes an inheritable DataFrameMethodTransformerInitTests class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Added
 
 Changed
 ^^^^^^^
+- Update DataFrameMethodTransformer tests to have inheritable init class that can be used by othe test files.
 - Moved BaseTransformer, DataFrameMethodTransformer, BaseMappingTransformer, BaseMappingTransformerMixin and Mapping Transformer over to the new testing framework.
 - Refactored MappingTransformer by removing redundant init method.
 

--- a/tests/base/test_DataFrameMethodTransformer.py
+++ b/tests/base/test_DataFrameMethodTransformer.py
@@ -15,12 +15,8 @@ from tests.base_tests import (
 from tubular.base import DataFrameMethodTransformer
 
 
-class TestInit(ColumnStrListInitTests):
-    """Tests for DataFrameMethodTransformer.init()."""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "DataFrameMethodTransformer"
+class DataFrameMethodTransformerInitTests(ColumnStrListInitTests):
+    """Inheritable tests for DataFrameMethodTransformer.init()."""
 
     @pytest.mark.parametrize("not_dictionary", ["a", [1, 2], True, 1.5])
     def test_exception_raised_pd_method_kwargs_not_dict(self, not_dictionary):
@@ -103,6 +99,12 @@ class TestInit(ColumnStrListInitTests):
                 columns=["b", "c"],
                 drop_original=not_bool,
             )
+
+
+class TestInit(DataFrameMethodTransformerInitTests):
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "DataFrameMethodTransformer"
 
 
 class TestFit(GenericFitTests):


### PR DESCRIPTION
I realised that DataFrameMethodTransformer contains a lot of input checks in the init method that are inherited and used by it's child classes, and have made the tests for these inheritable.

As an aside, the only child class of DataFrameMethodTransformer is TwoColumnOperatorTransformer.