### PR TITLE
Feature/refactor CrossColumnMappingTransformer tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,8 +26,9 @@ Added
 Changed
 ^^^^^^^
 - Update DataFrameMethodTransformer tests to have inheritable init class that can be used by othe test files.
-- Moved BaseTransformer, DataFrameMethodTransformer, BaseMappingTransformer, BaseMappingTransformerMixin and Mapping Transformer over to the new testing framework.
+- Moved BaseTransformer, DataFrameMethodTransformer, BaseMappingTransformer, BaseMappingTransformerMixin, CrossColumnMappingTransformer and Mapping Transformer over to the new testing framework.
 - Refactored MappingTransformer by removing redundant init method.
+- Updated tests for 
 
 Removed
 ^^^^^^^

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -267,7 +267,7 @@ class GenericFitTests:
 
 class GenericTransformTests:
     """
-    Generic tests for transformer.fit().
+    Generic tests for transformer.transform().
     Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
     """
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -21,25 +21,25 @@ class GenericInitTests:
     Note this class name deliberately avoids starting with "Tests" so that the tests are not run on import.
     """
 
-    def test_print(self, instantiated_transformers):
+    def test_print(self, initialized_transformers):
         """Test that transformer can be printed.
         If an error is raised in this test it will not prevent the transformer from working correctly,
         but will stop other unit tests passing.
         """
 
-        print(instantiated_transformers[self.transformer_name])
+        print(initialized_transformers[self.transformer_name])
 
-    def test_clone(self, instantiated_transformers):
+    def test_clone(self, initialized_transformers):
         """Test that transformer can be used in sklearn.base.clone function."""
 
-        b.clone(instantiated_transformers[self.transformer_name])
+        b.clone(initialized_transformers[self.transformer_name])
 
     @pytest.mark.parametrize("non_bool", [1, "True", {"a": 1}, [1, 2], None])
     def test_verbose_non_bool_error(
         self,
         non_bool,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         """Test an error is raised if verbose is not specified as a bool."""
 
@@ -47,7 +47,7 @@ class GenericInitTests:
             TypeError,
             match=f"{self.transformer_name}: verbose must be a bool",
         ):
-            uninstantiated_transformers[self.transformer_name](
+            uninitialized_transformers[self.transformer_name](
                 verbose=non_bool,
                 **minimal_attribute_dict[self.transformer_name],
             )
@@ -57,7 +57,7 @@ class GenericInitTests:
         self,
         non_bool,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         """Test an error is raised if copy is not specified as a bool."""
 
@@ -65,7 +65,7 @@ class GenericInitTests:
             TypeError,
             match=f"{self.transformer_name}: copy must be a bool",
         ):
-            uninstantiated_transformers[self.transformer_name](
+            uninitialized_transformers[self.transformer_name](
                 copy=non_bool,
                 **minimal_attribute_dict[self.transformer_name],
             )
@@ -80,7 +80,7 @@ class ColumnStrListInitTests(GenericInitTests):
     def test_columns_empty_list_error(
         self,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         """Test an error is raised if columns is specified as an empty list."""
 
@@ -88,14 +88,14 @@ class ColumnStrListInitTests(GenericInitTests):
         args["columns"] = []
 
         with pytest.raises(ValueError):
-            uninstantiated_transformers[self.transformer_name](**args)
+            uninitialized_transformers[self.transformer_name](**args)
 
     @pytest.mark.parametrize("non_string", [1, True, {"a": 1}, [1, 2], None])
     def test_columns_list_element_error(
         self,
         non_string,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         """Test an error is raised if columns list contains non-string elements."""
 
@@ -108,14 +108,14 @@ class ColumnStrListInitTests(GenericInitTests):
                 f"{self.transformer_name}: each element of columns should be a single (string) column name",
             ),
         ):
-            uninstantiated_transformers[self.transformer_name](**args)
+            uninitialized_transformers[self.transformer_name](**args)
 
     @pytest.mark.parametrize("non_string_or_list", [1, True, {"a": 1}, None])
     def test_columns_non_string_or_list_error(
         self,
         non_string_or_list,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         """Test an error is raised if columns is not passed as a string or list."""
 
@@ -128,7 +128,7 @@ class ColumnStrListInitTests(GenericInitTests):
                 f"{self.transformer_name}: columns must be a string or list with the columns to be pre-processed (if specified)",
             ),
         ):
-            uninstantiated_transformers[self.transformer_name](**args)
+            uninitialized_transformers[self.transformer_name](**args)
 
 
 class ColumnsFromDictInitTests(GenericInitTests):
@@ -142,7 +142,7 @@ class ColumnsFromDictInitTests(GenericInitTests):
         self,
         non_string,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         """Test an error is raised if columns list contains non-string elements."""
 
@@ -155,7 +155,7 @@ class ColumnsFromDictInitTests(GenericInitTests):
                 f"{self.transformer_name}: each element of columns should be a single (string) column name",
             ),
         ):
-            uninstantiated_transformers[self.transformer_name](**args)
+            uninitialized_transformers[self.transformer_name](**args)
 
 
 class GenericFitTests:
@@ -166,13 +166,13 @@ class GenericFitTests:
 
     def test_fit_returns_self(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test fit returns self?."""
 
         df = d.create_numeric_df_1()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         x_fitted = x.fit(df, df["c"])
 
@@ -183,14 +183,14 @@ class GenericFitTests:
     @pytest.mark.parametrize("non_df", [1, True, "a", [1, 2], {"a": 1}, None])
     def test_X_non_df_error(
         self,
-        instantiated_transformers,
+        initialized_transformers,
         non_df,
     ):
         """Test an error is raised if X is not passed as a pd.DataFrame."""
 
         df = d.create_numeric_df_1()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.raises(
             TypeError,
@@ -202,13 +202,13 @@ class GenericFitTests:
     def test_non_pd_type_error(
         self,
         non_series,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an error is raised if y is not passed as a pd.Series."""
 
         df = d.create_numeric_df_1()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.raises(
             TypeError,
@@ -218,11 +218,11 @@ class GenericFitTests:
 
     def test_X_no_rows_error(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an error is raised if X has no rows."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         df = pd.DataFrame(columns=["a", "b", "c"])
 
@@ -234,11 +234,11 @@ class GenericFitTests:
 
     def test_Y_no_rows_error(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an error is raised if Y has no rows."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         df = pd.DataFrame({"a": 1, "b": "wow", "c": np.nan}, index=[0])
 
@@ -251,7 +251,7 @@ class GenericFitTests:
     def test_unexpected_kwarg_error(
         self,
         minimal_attribute_dict,
-        uninstantiated_transformers,
+        uninitialized_transformers,
     ):
         with pytest.raises(
             TypeError,
@@ -259,7 +259,7 @@ class GenericFitTests:
                 "__init__() got an unexpected keyword argument 'unexpected_kwarg'",
             ),
         ):
-            uninstantiated_transformers[self.transformer_name](
+            uninitialized_transformers[self.transformer_name](
                 unexpected_kwarg="spanish inquisition",
                 **minimal_attribute_dict[self.transformer_name],
             )
@@ -275,13 +275,13 @@ class GenericTransformTests:
     def test_non_pd_type_error(
         self,
         non_df,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test that an error is raised in transform is X is not a pd.DataFrame."""
 
         df = d.create_df_10()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         x_fitted = x.fit(df, df["c"])
 
@@ -291,11 +291,11 @@ class GenericTransformTests:
         ):
             x_fitted.transform(X=non_df)
 
-    def test_copy_returned(self, minimal_attribute_dict, uninstantiated_transformers):
+    def test_copy_returned(self, minimal_attribute_dict, uninitialized_transformers):
         """Test check that a copy is returned if copy is set to True"""
         df = d.create_df_10()
 
-        x = uninstantiated_transformers[self.transformer_name](
+        x = uninitialized_transformers[self.transformer_name](
             copy=True,
             **minimal_attribute_dict[self.transformer_name],
         )
@@ -306,11 +306,11 @@ class GenericTransformTests:
 
         assert df_transformed is not df
 
-    def test_no_rows_error(self, instantiated_transformers):
+    def test_no_rows_error(self, initialized_transformers):
         """Test an error is raised if X has no rows."""
         df = d.create_df_10()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         x = x.fit(df, df["c"])
 
@@ -331,11 +331,11 @@ class ColumnsCheckTests:
 
     def test_non_pd_df_error(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an error is raised if X is not passed as a pd.DataFrame."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.raises(
             TypeError,
@@ -347,12 +347,12 @@ class ColumnsCheckTests:
     def test_columns_not_list_error(
         self,
         non_list,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an error is raised if self.columns is not a list."""
         df = d.create_df_1()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         x.columns = non_list
 
@@ -364,12 +364,12 @@ class ColumnsCheckTests:
 
     def test_columns_not_in_X_error(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an error is raised if self.columns contains a value not in X."""
         df = d.create_df_1()
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         x.columns = ["a", "z"]
 
@@ -387,11 +387,11 @@ class CombineXYTests:
     def test_X_not_DataFrame_error(
         self,
         non_df,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an exception is raised if X is not a pd.DataFrame."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.raises(
             TypeError,
@@ -403,11 +403,11 @@ class CombineXYTests:
     def test_y_not_Series_error(
         self,
         non_series,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an exception is raised if y is not a pd.Series."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.raises(
             TypeError,
@@ -417,11 +417,11 @@ class CombineXYTests:
 
     def test_X_and_y_different_number_of_rows_error(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test an exception is raised if X and y have different numbers of rows."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.raises(
             ValueError,
@@ -433,11 +433,11 @@ class CombineXYTests:
 
     def test_X_and_y_different_indexes_warning(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test a warning is raised if X and y have different indexes, but the output is still X and y."""
 
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         with pytest.warns(
             UserWarning,
@@ -450,10 +450,10 @@ class CombineXYTests:
 
     def test_output_same_indexes(
         self,
-        instantiated_transformers,
+        initialized_transformers,
     ):
         """Test output is correct if X and y have the same index."""
-        x = instantiated_transformers[self.transformer_name]
+        x = initialized_transformers[self.transformer_name]
 
         result = x._combine_X_y(
             X=pd.DataFrame({"a": [1, 2]}, index=[1, 2]),
@@ -499,14 +499,14 @@ class CheckWeightsColumnTests:
         ]
 
     @pytest.mark.parametrize("df, error, col", get_df_error_combos())
-    def test_weight_not_in_X_error(self, df, error, col, uninstantiated_transformers):
+    def test_weight_not_in_X_error(self, df, error, col, uninitialized_transformers):
         """Test an error is raised if weight is not in X."""
 
         with pytest.raises(
             ValueError,
             match=error,
         ):
-            uninstantiated_transformers[self.transformer_name].check_weights_column(
+            uninitialized_transformers[self.transformer_name].check_weights_column(
                 df,
                 col,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,12 +222,12 @@ def minimal_attribute_dict():
 
 
 @pytest.fixture()
-def instantiated_transformers(minimal_attribute_dict):
+def initialized_transformers(minimal_attribute_dict):
     """dictionary of {transformer name : initiated transformer} pairs for all transformers"""
     return {x[0]: x[1](**minimal_attribute_dict[x[0]]) for x in get_all_classes()}
 
 
 @pytest.fixture()
-def uninstantiated_transformers():
+def uninitialized_transformers():
     """dictionary of {transformer name : uninitiated transformer} pairs for all transformers"""
     return {x[0]: x[1] for x in get_all_classes()}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,24 @@ import pytest
 
 import tubular.base as base
 
+"""
+How To Use This Testing Framework
+-----------------------------------
+
+Fixtures in this file are used in tests for shared behaviour which can be run on multiple transformers through inheritance.
+setup_class is defined in each test class to define cls.transformer_name as the name of the transformer being tested.
+
+Test methods for shared behaviour are defined in base_tests.py or child test classes which are themselves inherited.  The
+fixtures in this file can be used in these tests to access initiated/ uninitiated transformers and minimum attributes for
+intiatialization.
+
+Test classes which can import tests for shared behaviour inherit from an appropriate parent and define cls.transformer_name
+in setup_class so that these fixtures will retrieve the appropriate transformer instance. setup_class is called by pytest
+at a class level before its test methods are run https://docs.pytest.org/en/8.0.x/how-to/xunit_setup.html.
+
+New transformers will need to be added to minimal_attribute_dict.
+ """
+
 
 def get_all_classes():
     root = str(Path(__file__).parent.parent)
@@ -40,6 +58,8 @@ def get_all_classes():
 
 @pytest.fixture()
 def minimal_attribute_dict():
+    """defines minmal attributes (values) needed to initiate each transformer named (key).
+    New transformers need to be added here"""
     return {
         "BaseTransformer": {
             "columns": ["a"],
@@ -203,9 +223,11 @@ def minimal_attribute_dict():
 
 @pytest.fixture()
 def instantiated_transformers(minimal_attribute_dict):
+    """dictionary of {transformer name : initiated transformer} pairs for all transformers"""
     return {x[0]: x[1](**minimal_attribute_dict[x[0]]) for x in get_all_classes()}
 
 
 @pytest.fixture()
 def uninstantiated_transformers():
+    """dictionary of {transformer name : uninitiated transformer} pairs for all transformers"""
     return {x[0]: x[1] for x in get_all_classes()}

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -22,7 +22,7 @@ class BaseMappingTransformerInitTests(ColumnsFromDictInitTests):
 
     def test_no_keys_dict_error(
         self,
-        uninstantiated_transformers,
+        uninitialized_transformers,
         minimal_attribute_dict,
     ):
         """Test that an exception is raised if mappings is a dict but with no keys."""
@@ -34,11 +34,11 @@ class BaseMappingTransformerInitTests(ColumnsFromDictInitTests):
             ValueError,
             match=f"{self.transformer_name}: mappings has no values",
         ):
-            uninstantiated_transformers[self.transformer_name](**kwargs)
+            uninitialized_transformers[self.transformer_name](**kwargs)
 
     def test_mappings_contains_non_dict_items_error(
         self,
-        uninstantiated_transformers,
+        uninitialized_transformers,
         minimal_attribute_dict,
     ):
         """Test that an exception is raised if mappings contains non-dict items."""
@@ -50,13 +50,13 @@ class BaseMappingTransformerInitTests(ColumnsFromDictInitTests):
             ValueError,
             match=f"{self.transformer_name}: values in mappings dictionary should be dictionaries",
         ):
-            uninstantiated_transformers[self.transformer_name](
+            uninitialized_transformers[self.transformer_name](
                 **kwargs,
             )
 
     def test_mappings_not_dict_error(
         self,
-        uninstantiated_transformers,
+        uninitialized_transformers,
         minimal_attribute_dict,
     ):
         """Test that an exception is raised if mappings is not a dict."""
@@ -68,7 +68,7 @@ class BaseMappingTransformerInitTests(ColumnsFromDictInitTests):
             ValueError,
             match=f"{self.transformer_name}: mappings must be a dictionary",
         ):
-            uninstantiated_transformers[self.transformer_name](**kwargs)
+            uninitialized_transformers[self.transformer_name](**kwargs)
 
 
 class BaseMappingTransformerTransformTests(GenericTransformTests):
@@ -77,7 +77,7 @@ class BaseMappingTransformerTransformTests(GenericTransformTests):
     Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
     """
 
-    def test_mappings_unchanged(self, uninstantiated_transformers):
+    def test_mappings_unchanged(self, uninitialized_transformers):
         """Test that mappings is unchanged in transform."""
         df = d.create_df_1()
 
@@ -86,7 +86,7 @@ class BaseMappingTransformerTransformTests(GenericTransformTests):
             "b": {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6},
         }
 
-        x = uninstantiated_transformers[self.transformer_name](mappings=mapping)
+        x = uninitialized_transformers[self.transformer_name](mappings=mapping)
 
         x.transform(df)
 
@@ -125,7 +125,7 @@ class TestTransform(BaseMappingTransformerTransformTests):
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_1(), d.create_df_1()),
     )
-    def test_X_returned(self, df, expected, uninstantiated_transformers):
+    def test_X_returned(self, df, expected, uninitialized_transformers):
         """Test that X is returned from transform."""
         mapping = {
             "a": {1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f"},

--- a/tests/mapping/test_BaseMappingTransformer.py
+++ b/tests/mapping/test_BaseMappingTransformer.py
@@ -20,31 +20,55 @@ class BaseMappingTransformerInitTests(ColumnsFromDictInitTests):
     Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
     """
 
-    def test_no_keys_dict_error(self, uninstantiated_transformers):
+    def test_no_keys_dict_error(
+        self,
+        uninstantiated_transformers,
+        minimal_attribute_dict,
+    ):
         """Test that an exception is raised if mappings is a dict but with no keys."""
+
+        kwargs = minimal_attribute_dict[self.transformer_name]
+        kwargs["mappings"] = {}
+
         with pytest.raises(
             ValueError,
             match=f"{self.transformer_name}: mappings has no values",
         ):
-            uninstantiated_transformers[self.transformer_name](mappings={})
+            uninstantiated_transformers[self.transformer_name](**kwargs)
 
-    def test_mappings_contains_non_dict_items_error(self, uninstantiated_transformers):
+    def test_mappings_contains_non_dict_items_error(
+        self,
+        uninstantiated_transformers,
+        minimal_attribute_dict,
+    ):
         """Test that an exception is raised if mappings contains non-dict items."""
+
+        kwargs = minimal_attribute_dict[self.transformer_name]
+        kwargs["mappings"] = {"a": {"a": 1}, "b": 1}
+
         with pytest.raises(
             ValueError,
             match=f"{self.transformer_name}: values in mappings dictionary should be dictionaries",
         ):
             uninstantiated_transformers[self.transformer_name](
-                mappings={"a": {"a": 1}, "b": 1},
+                **kwargs,
             )
 
-    def test_mappings_not_dict_error(self, uninstantiated_transformers):
+    def test_mappings_not_dict_error(
+        self,
+        uninstantiated_transformers,
+        minimal_attribute_dict,
+    ):
         """Test that an exception is raised if mappings is not a dict."""
+
+        kwargs = minimal_attribute_dict[self.transformer_name]
+        kwargs["mappings"] = ()
+
         with pytest.raises(
             ValueError,
             match=f"{self.transformer_name}: mappings must be a dictionary",
         ):
-            uninstantiated_transformers[self.transformer_name](mappings=())
+            uninstantiated_transformers[self.transformer_name](**kwargs)
 
 
 class BaseMappingTransformerTransformTests(GenericTransformTests):

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -5,34 +5,21 @@ import pytest
 import test_aide as ta
 
 import tests.test_data as d
-import tubular
+from tests.mapping.test_BaseMappingTransformer import (
+    BaseMappingTransformerInitTests,
+    BaseMappingTransformerTransformTests,
+    GenericFitTests,
+    OtherBaseBehaviourTests,
+)
 from tubular.mapping import CrossColumnMappingTransformer
 
 
-class TestInit:
+class TestInit(BaseMappingTransformerInitTests):
     """Tests for CrossColumnMappingTransformer.init()."""
 
-    def test_super_init_called(self, mocker):
-        """Test that init calls BaseMappingTransformer.init."""
-        expected_call_args = {
-            0: {
-                "args": (),
-                "kwargs": {"mappings": {"a": {"a": 1}}, "verbose": True, "copy": True},
-            },
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.mapping.BaseMappingTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            CrossColumnMappingTransformer(
-                mappings={"a": {"a": 1}},
-                adjust_column="b",
-                verbose=True,
-                copy=True,
-            )
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "CrossColumnMappingTransformer"
 
     def test_adjust_columns_non_string_error(self):
         """Test that an exception is raised if adjust_column is not a string."""
@@ -53,21 +40,21 @@ class TestInit:
                 adjust_column="c",
             )
 
-    def test_adjust_column_set_to_attribute(self):
-        """Test that the value passed for adjust_column is saved in an attribute of the same name."""
-        value = "b"
 
-        x = CrossColumnMappingTransformer(mappings={"a": {"a": 1}}, adjust_column=value)
+class TestFit(GenericFitTests):
+    """Generic tests for CrossColumnMappingTransformer.fit()"""
 
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={"adjust_column": value},
-            msg="Attributes for CrossColumnMappingTransformer set in init",
-        )
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "CrossColumnMappingTransformer"
 
 
-class TestTransform:
+class TestTransform(BaseMappingTransformerTransformTests):
     """Tests for the transform method on CrossColumnMappingTransformer."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "CrossColumnMappingTransformer"
 
     def expected_df_1():
         """Expected output for test_expected_output."""
@@ -90,43 +77,6 @@ class TestTransform:
                 "c": ["cc", "dd", "bb", "cc", "cc"],
             },
         )
-
-    def test_check_is_fitted_call(self, mocker):
-        """Test the call to check_is_fitted."""
-        df = d.create_df_1()
-
-        mapping = {"a": {1: "a", 2: "b", 3: "c", 4: "d", 5: "e", 6: "f"}}
-
-        x = CrossColumnMappingTransformer(mappings=mapping, adjust_column="b")
-
-        expected_call_args = {0: {"args": (["adjust_column"],), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "check_is_fitted",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    def test_super_transform_call(self, mocker):
-        """Test the call to BaseMappingTransformer.transform."""
-        df = d.create_df_1()
-
-        mapping = {"a": {1: "aa", 2: "bb", 3: "cc", 4: "dd", 5: "ee", 6: "ff"}}
-
-        x = CrossColumnMappingTransformer(mappings=mapping, adjust_column="b")
-
-        expected_call_args = {0: {"args": (d.create_df_1(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.mapping.BaseMappingTransformer,
-            "transform",
-            expected_call_args,
-            return_value=d.create_df_1(),
-        ):
-            x.transform(df)
 
     def test_adjust_col_not_in_x_error(self):
         """Test that an exception is raised if the adjust_column is not present in the dataframe."""
@@ -214,3 +164,15 @@ class TestTransform:
             actual=x.mappings,
             msg="CrossColumnMappingTransformer.transform has changed self.mappings unexpectedly",
         )
+
+
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
+
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "CrossColumnMappingTransformer"

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -19,6 +19,8 @@ class TestInit(BaseMappingTransformerInitTests):
 
     @classmethod
     def setup_class(cls):
+        """Defines which transformer look up in conftest.py fixtures for inherited tests.
+        setup_class is called by pytest at class level before all test methods are called."""
         cls.transformer_name = "CrossColumnMappingTransformer"
 
     def test_adjust_columns_non_string_error(self):

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -19,8 +19,6 @@ class TestInit(BaseMappingTransformerInitTests):
 
     @classmethod
     def setup_class(cls):
-        """Defines which transformer look up in conftest.py fixtures for inherited tests.
-        setup_class is called by pytest at class level before all test methods are called."""
         cls.transformer_name = "CrossColumnMappingTransformer"
 
     def test_adjust_columns_non_string_error(self):

--- a/tests/mapping/test_CrossColumnMappingTransformer.py
+++ b/tests/mapping/test_CrossColumnMappingTransformer.py
@@ -78,20 +78,6 @@ class TestTransform(BaseMappingTransformerTransformTests):
             },
         )
 
-    def test_adjust_col_not_in_x_error(self):
-        """Test that an exception is raised if the adjust_column is not present in the dataframe."""
-        df = d.create_df_1()
-
-        mapping = {"a": {1: "aa", 2: "bb", 3: "cc", 4: "dd", 5: "ee", 6: "ff"}}
-
-        x = CrossColumnMappingTransformer(mappings=mapping, adjust_column="c")
-
-        with pytest.raises(
-            ValueError,
-            match="CrossColumnMappingTransformer: variable c is not in X",
-        ):
-            x.transform(df)
-
     @pytest.mark.parametrize(
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_1(), expected_df_1()),


### PR DESCRIPTION
Applying the new testing framework to CrossColumnMappingTransformer.

Broadly very simple, although I had to modify some tests in BaseMappingTransformerInitTests to be more generally applicable by calling the minimal_attribute_dict fixture.

After struggling a little with this at first I added some documentation to explain how to use those fixtures and the interaction with  with setup_class methods.  Initially tried adding docstring explaining when it is called to every setup_class method but this was very messy, seemed excessive to repeat so much, and did not seem as helpful as having the framework explained in one place.