### PR TITLE
Remove fillna call in ArbitraryImputer (Issue 195)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,6 +29,7 @@ Changed
 - Moved BaseTransformer, DataFrameMethodTransformer, BaseMappingTransformer, BaseMappingTransformerMixin, CrossColumnMappingTransformer and Mapping Transformer over to the new testing framework.
 - Refactored MappingTransformer by removing redundant init method.
 - Updated tests for 
+- Refactored ArbitraryImputer by removing redundant fillna call in transform method. This should increase tubular's efficiency and maintainability.
 
 Removed
 ^^^^^^^

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -93,11 +93,11 @@ class TestTransform:
 
         x = ArbitraryImputer(impute_value=1, columns=["a", "b", "c"])
 
-        # mock BaseImputer.transform so it does not run
+        # mock BaseImputer.transform to return a Dataframe so it does not run
         mocker.patch.object(
             tubular.imputers.BaseImputer,
             "transform",
-            return_value=1234,
+            return_value=df.copy(),
         )
 
         x.transform(df)

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -19,8 +19,8 @@ class BaseImputerTransformTests(GenericTransformTests):
         df = pd.DataFrame(
             {
                 "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
-                "b": ["a", "b", "c", "d", "e", "f", np.NaN],
-                "c": ["a", "b", "c", "d", "e", "f", np.NaN],
+                "b": ["a", "b", "c", "d", "e", "f", np.nan],
+                "c": ["a", "b", "c", "d", "e", "f", np.nan],
             },
         )
 

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -113,18 +113,19 @@ class ArbitraryImputer(BaseImputer):
                 X[c] = X[c].cat.add_categories(
                     self.impute_value,
                 )  # add new category
-
-            dtype = X[c].dtype  # get the dtype of column
-
-            X[c] = (
-                X[c].fillna(self.impute_values_).astype(dtype)
-            )  # casting imputer value as same dtype
-
             self.impute_values_[
                 c
             ] = self.impute_value  # updating impute_values_ attribute
 
-        return super().transform(X)  # impute the values
+        # Calling the BaseImputer's transform method to impute the values
+        X_transformed = super().transform(X)
+
+        # casting imputer value as same dtype as original column
+        for c in self.columns:
+            dtype = X[c].dtype  # get the dtype of original column
+            X_transformed[c] = X_transformed[c].astype(dtype)
+
+        return X_transformed
 
 
 class MedianImputer(BaseImputer):


### PR DESCRIPTION
ArbitraryImputer was calling fillna both in it's own transform method, and in the BaseImputer method.

To increase tubular's efficiency and maintainability, have removed fillna call in ArbitraryImputer and moved the logic for "casting imputer value as same dtype as original column" below the BaseImputer.transform call.

Note that the above change caused the test_impute_values_set in test_ArbitraryImputer.py to fail since the initial mock setup for BaseImputer.transform was returning a simple integer:1234. However, this causes 'TypeError: 'int' object is not superscriptable' for the following code line in transform method of ArbitraryImputer: X_transformed[c] = X_transformed[c].astype(dtype), since an integer cannot be treated as a collection. Therefore have updated test_impute_values_set to mock BaseImputer.transform to return a dataframe rather than an int