### PR TITLE
setup ArbitraryTransformer with new testing appraoch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ Changed
 - Refactored MappingTransformer by removing redundant init method.
 - Updated tests for 
 - Refactored ArbitraryImputer by removing redundant fillna call in transform method. This should increase tubular's efficiency and maintainability.
+- Refactored ArbitraryImputer and BaseImputer tests in new format.
 
 Removed
 ^^^^^^^

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -1,144 +1,54 @@
 import pytest
-import test_aide as ta
 
 import tests.test_data as d
-import tubular
+from tests.base_tests import (
+    ColumnStrListInitTests,
+    GenericFitTests,
+    GenericTransformTests,
+    OtherBaseBehaviourTests,
+)
+from tests.imputers.test_BaseImputer import GenericImputerTransformTests
 from tubular.imputers import ArbitraryImputer
 
 
-class TestInit:
-    """Tests for ArbitraryImputer.init()."""
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
 
-    def test_super_init_called(self, mocker):
-        """Test that init calls BaseTransformer.init."""
-        expected_call_args = {
-            0: {"args": (), "kwargs": {"columns": "a", "verbose": True}},
-        }
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"
 
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            ArbitraryImputer(impute_value=1, columns="a", verbose=True)
-
-    def test_columns_none_error(self):
-        """Test that an exception is raised if columns is passed as None."""
-        with pytest.raises(
-            ValueError,
-            match="ArbitraryImputer: columns must be specified in init for ArbitraryImputer",
-        ):
-            ArbitraryImputer(impute_value=1, columns=None)
-
-    def test_impute_value_type_error(self):
+    def test_impute_value_type_error(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+    ):
         """Test that an exception is raised if impute_value is not an int, float or str."""
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["impute_value"] = [1, 2]
+
         with pytest.raises(
             ValueError,
             match="ArbitraryImputer: impute_value should be a single value .*",
         ):
-            ArbitraryImputer(impute_value={}, columns="a")
-
-    def test_impute_values_set_to_attribute(self):
-        """Test that the value passed for impute_value is saved in an attribute of the same name."""
-        value = 1
-
-        x = ArbitraryImputer(impute_value=value, columns="a")
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={"impute_value": value, "impute_values_": {}},
-            msg="Attributes for ArbitraryImputer set in init",
-        )
+            uninitialized_transformers[self.transformer_name](**args)
 
 
-class TestTransform:
-    """Tests for ArbitraryImputer.transform()."""
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
 
-    def test_check_is_fitted_called(self, mocker):
-        """Test that BaseTransformer check_is_fitted called."""
-        df = d.create_df_1()
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"
 
-        x = ArbitraryImputer(impute_value=1, columns="a")
 
-        expected_call_args = {0: {"args": (["impute_value"],), "kwargs": {}}}
+class TestTransform(GenericImputerTransformTests, GenericTransformTests):
+    """Tests for transformer.transform."""
 
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "check_is_fitted",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    def test_super_transform_called(self, mocker):
-        """Test that BaseImputer.transform called."""
-        df = d.create_df_2()
-
-        x = ArbitraryImputer(impute_value=1, columns="a")
-
-        expected_call_args = {0: {"args": (d.create_df_2(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.imputers.BaseImputer,
-            "transform",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    def test_impute_values_set(self, mocker):
-        """Test that impute_values_ are set with imput_value in transform."""
-        df = d.create_df_2()
-
-        x = ArbitraryImputer(impute_value=1, columns=["a", "b", "c"])
-
-        # mock BaseImputer.transform to return a Dataframe so it does not run
-        mocker.patch.object(
-            tubular.imputers.BaseImputer,
-            "transform",
-            return_value=df.copy(),
-        )
-
-        x.transform(df)
-
-        assert x.impute_values_ == {
-            "a": 1,
-            "b": 1,
-            "c": 1,
-        }, "impute_values_ not set with imput_value in transform"
-
-    def test_impute_value_unchanged(self):
-        """Test that self.impute_value is unchanged after transform."""
-        df = d.create_df_1()
-
-        value = 1
-
-        x = ArbitraryImputer(impute_value=value, columns="a")
-
-        x.transform(df)
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={"impute_value": value},
-            msg="impute_value changed in transform",
-        )
-
-    def test_super_columns_check_called(self, mocker):
-        """Test that BaseTransformer.columns_check called."""
-        df = d.create_df_2()
-
-        x = ArbitraryImputer(impute_value=-1, columns="a")
-
-        expected_call_args = {0: {"args": (d.create_df_2(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "columns_check",
-            expected_call_args,
-        ):
-            x.transform(df)
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"
 
     # Unit testing to check if downcast datatypes of columns is preserved after imputation is done
     def test_impute_value_preserve_dtype(self):
@@ -167,3 +77,15 @@ class TestTransform:
         # Checking if the dtype of "a" and "b" are int8 and float16 respectively after imputation
         assert df["a"].dtype == "int8"
         assert df["b"].dtype == "float16"
+
+
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
+
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -134,10 +134,15 @@ class GenericImputerTransformTests:
 
         x1.impute_values_ = {"b": "g", "c": "f"}
         x1.columns = ["b", "c"]
-        # bit of a hack to make this work nicely for arbitrary imputer
-        x1.impute_value = "f"
 
         df_transformed = x1.transform(df)
+
+        # arb imputer will add a new categorical level to cat columns,
+        # make sure expected takes this into account
+        if self.transformer_name == "ArbitraryImputer":
+            expected["c"] = expected["c"].cat.add_categories(
+                x1.impute_value,
+            )
 
         ta.equality.assert_equal_dispatch(
             expected=expected,

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -8,50 +10,40 @@ import tests.test_data as d
 from tests.base_tests import (
     ColumnStrListInitTests,
     GenericFitTests,
-    GenericTransformTests,
     OtherBaseBehaviourTests,
 )
-from tubular.imputers import BaseImputer
 
 
-class BaseImputerTransformTests(GenericTransformTests):
-    def test_not_fitted_error_raised(self):
-        df = pd.DataFrame(
-            {
-                "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
-                "b": ["a", "b", "c", "d", "e", "f", np.nan],
-                "c": ["a", "b", "c", "d", "e", "f", np.nan],
-            },
+class GenericImputerTransformTests:
+    def test_not_fitted_error_raised(self, initialized_transformers):
+        if initialized_transformers[self.transformer_name].FITS:
+            df = pd.DataFrame(
+                {
+                    "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                    "b": ["a", "b", "c", "d", "e", "f", np.nan],
+                    "c": ["a", "b", "c", "d", "e", "f", np.nan],
+                },
+            )
+
+            with pytest.raises(NotFittedError):
+                initialized_transformers[self.transformer_name].transform(df)
+
+    def test_impute_value_unchanged(self, initialized_transformers):
+        """Test that self.impute_value is unchanged after transform."""
+        df = d.create_df_1()
+
+        transformer = initialized_transformers[self.transformer_name]
+        transformer.impute_values_ = {"a": 1}
+
+        impute_values = deepcopy(transformer.impute_values_)
+
+        transformer.transform(df)
+
+        ta.classes.test_object_attributes(
+            obj=transformer,
+            expected_attributes={"impute_values_": impute_values},
+            msg="impute_values_ changed in transform",
         )
-
-        x = BaseImputer(columns=["b", "c"])
-
-        with pytest.raises(NotFittedError):
-            x.transform(df)
-
-
-class TestInit(ColumnStrListInitTests):
-    """Generic tests for transformer.init()."""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "BaseImputer"
-
-
-class TestFit(GenericFitTests):
-    """Generic tests for transformer.fit()"""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "BaseTransformer"
-
-
-class TestTransform(BaseImputerTransformTests):
-    """Tests for BaseImputer.transform."""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "BaseTransformer"
 
     def expected_df_1():
         """Expected output of test_expected_output_1."""
@@ -99,54 +91,83 @@ class TestTransform(BaseImputerTransformTests):
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_2(), expected_df_1()),
     )
-    def test_expected_output_1(self, df, expected):
+    def test_expected_output_1(self, df, expected, initialized_transformers):
         """Test that transform is giving the expected output when applied to float column."""
-        x1 = BaseImputer(columns="a")
+        x1 = initialized_transformers[self.transformer_name]
         x1.impute_values_ = {"a": 7}
+        x1.columns = ["a"]
 
         df_transformed = x1.transform(df)
 
         ta.equality.assert_equal_dispatch(
             expected=expected,
             actual=df_transformed,
-            msg="ArbitraryImputer transform col a",
+            msg=f"Error from {self.transformer_name} transform col a",
         )
 
     @pytest.mark.parametrize(
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_2(), expected_df_2()),
     )
-    def test_expected_output_2(self, df, expected):
+    def test_expected_output_2(self, df, expected, initialized_transformers):
         """Test that transform is giving the expected output when applied to object column."""
-        x1 = BaseImputer(columns=["b"])
+        x1 = initialized_transformers[self.transformer_name]
 
         x1.impute_values_ = {"b": "g"}
+        x1.columns = ["b"]
 
         df_transformed = x1.transform(df)
 
         ta.equality.assert_equal_dispatch(
             expected=expected,
             actual=df_transformed,
-            msg="ArbitraryImputer transform col b",
+            msg=f"Error from {self.transformer_name} transform col b",
         )
 
     @pytest.mark.parametrize(
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_2(), expected_df_3()),
     )
-    def test_expected_output_3(self, df, expected):
+    def test_expected_output_3(self, df, expected, initialized_transformers):
         """Test that transform is giving the expected output when applied to object and categorical columns."""
-        x1 = BaseImputer(columns=["b", "c"])
+        x1 = initialized_transformers[self.transformer_name]
 
         x1.impute_values_ = {"b": "g", "c": "f"}
+        x1.columns = ["b", "c"]
+        # bit of a hack to make this work nicely for arbitrary imputer
+        x1.impute_value = "f"
 
         df_transformed = x1.transform(df)
 
         ta.equality.assert_equal_dispatch(
             expected=expected,
             actual=df_transformed,
-            msg="ArbitraryImputer transform col b, c",
+            msg=f"Error from {self.transformer_name} transform col b, c",
         )
+
+
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseImputer"
+
+
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseImputer"
+
+
+class TestTransform(GenericImputerTransformTests):
+    """Tests for BaseImputer.transform."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseImputer"
 
 
 class TestOtherBaseBehaviour(OtherBaseBehaviourTests):

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -17,6 +17,8 @@ class BaseImputer(BaseTransformer):
     Other imputers in this module should inherit from this class.
     """
 
+    FITS = False
+
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Impute missing values with median values calculated from fit method.
 
@@ -60,16 +62,14 @@ class ArbitraryImputer(BaseImputer):
         Value to impute nulls with.
     """
 
+    FITS = False
+
     def __init__(
         self,
         impute_value: float | str,
-        columns: str | list[str] | None = None,
+        columns: str | list[str],
         **kwargs: dict[str, bool],
     ) -> None:
-        if columns is None:
-            msg = f"{self.classname()}: columns must be specified in init for ArbitraryImputer"
-            raise ValueError(msg)
-
         super().__init__(columns=columns, **kwargs)
 
         if (
@@ -82,6 +82,9 @@ class ArbitraryImputer(BaseImputer):
 
         self.impute_values_ = {}
         self.impute_value = impute_value
+
+        for c in self.columns:
+            self.impute_values_[c] = self.impute_value
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Impute missing values with the supplied impute_value.
@@ -113,9 +116,6 @@ class ArbitraryImputer(BaseImputer):
                 X[c] = X[c].cat.add_categories(
                     self.impute_value,
                 )  # add new category
-            self.impute_values_[
-                c
-            ] = self.impute_value  # updating impute_values_ attribute
 
         # Calling the BaseImputer's transform method to impute the values
         X_transformed = super().transform(X)


### PR DESCRIPTION
Issue: https://github.com/lvgig/tubular/issues/207

Made changes to bring ArbitraryImputer in line with new test format, also refactored BaseImputer tests to ease the rest of the rollout across imputers. 

Introduced new 'FITS' class attribute to simplify test inheritance process and turning on/off relevant tests, if the reviewer approves then suggest to rollout across transformers. Possibly default to True in BaseTransformer and set to False where needed in main transformers. 