### PR TITLE
Feature/mode imputer test overhaul

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,6 +130,7 @@ def minimal_attribute_dict():
         },
         "ModeImputer": {
             "columns": ["a"],
+            "weight": None,
         },
         "NearestMeanResponseImputer": {
             "columns": ["a"],

--- a/tests/imputers/test_ArbitraryImputer.py
+++ b/tests/imputers/test_ArbitraryImputer.py
@@ -1,144 +1,54 @@
 import pytest
-import test_aide as ta
 
 import tests.test_data as d
-import tubular
+from tests.base_tests import (
+    ColumnStrListInitTests,
+    GenericFitTests,
+    GenericTransformTests,
+    OtherBaseBehaviourTests,
+)
+from tests.imputers.test_BaseImputer import GenericImputerTransformTests
 from tubular.imputers import ArbitraryImputer
 
 
-class TestInit:
-    """Tests for ArbitraryImputer.init()."""
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
 
-    def test_super_init_called(self, mocker):
-        """Test that init calls BaseTransformer.init."""
-        expected_call_args = {
-            0: {"args": (), "kwargs": {"columns": "a", "verbose": True}},
-        }
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"
 
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            ArbitraryImputer(impute_value=1, columns="a", verbose=True)
-
-    def test_columns_none_error(self):
-        """Test that an exception is raised if columns is passed as None."""
-        with pytest.raises(
-            ValueError,
-            match="ArbitraryImputer: columns must be specified in init for ArbitraryImputer",
-        ):
-            ArbitraryImputer(impute_value=1, columns=None)
-
-    def test_impute_value_type_error(self):
+    def test_impute_value_type_error(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+    ):
         """Test that an exception is raised if impute_value is not an int, float or str."""
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["impute_value"] = [1, 2]
+
         with pytest.raises(
             ValueError,
             match="ArbitraryImputer: impute_value should be a single value .*",
         ):
-            ArbitraryImputer(impute_value={}, columns="a")
-
-    def test_impute_values_set_to_attribute(self):
-        """Test that the value passed for impute_value is saved in an attribute of the same name."""
-        value = 1
-
-        x = ArbitraryImputer(impute_value=value, columns="a")
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={"impute_value": value, "impute_values_": {}},
-            msg="Attributes for ArbitraryImputer set in init",
-        )
+            uninitialized_transformers[self.transformer_name](**args)
 
 
-class TestTransform:
-    """Tests for ArbitraryImputer.transform()."""
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
 
-    def test_check_is_fitted_called(self, mocker):
-        """Test that BaseTransformer check_is_fitted called."""
-        df = d.create_df_1()
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"
 
-        x = ArbitraryImputer(impute_value=1, columns="a")
 
-        expected_call_args = {0: {"args": (["impute_value"],), "kwargs": {}}}
+class TestTransform(GenericImputerTransformTests, GenericTransformTests):
+    """Tests for transformer.transform."""
 
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "check_is_fitted",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    def test_super_transform_called(self, mocker):
-        """Test that BaseImputer.transform called."""
-        df = d.create_df_2()
-
-        x = ArbitraryImputer(impute_value=1, columns="a")
-
-        expected_call_args = {0: {"args": (d.create_df_2(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.imputers.BaseImputer,
-            "transform",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    def test_impute_values_set(self, mocker):
-        """Test that impute_values_ are set with imput_value in transform."""
-        df = d.create_df_2()
-
-        x = ArbitraryImputer(impute_value=1, columns=["a", "b", "c"])
-
-        # mock BaseImputer.transform to return a Dataframe so it does not run
-        mocker.patch.object(
-            tubular.imputers.BaseImputer,
-            "transform",
-            return_value=df.copy(),
-        )
-
-        x.transform(df)
-
-        assert x.impute_values_ == {
-            "a": 1,
-            "b": 1,
-            "c": 1,
-        }, "impute_values_ not set with imput_value in transform"
-
-    def test_impute_value_unchanged(self):
-        """Test that self.impute_value is unchanged after transform."""
-        df = d.create_df_1()
-
-        value = 1
-
-        x = ArbitraryImputer(impute_value=value, columns="a")
-
-        x.transform(df)
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={"impute_value": value},
-            msg="impute_value changed in transform",
-        )
-
-    def test_super_columns_check_called(self, mocker):
-        """Test that BaseTransformer.columns_check called."""
-        df = d.create_df_2()
-
-        x = ArbitraryImputer(impute_value=-1, columns="a")
-
-        expected_call_args = {0: {"args": (d.create_df_2(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "columns_check",
-            expected_call_args,
-        ):
-            x.transform(df)
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"
 
     # Unit testing to check if downcast datatypes of columns is preserved after imputation is done
     def test_impute_value_preserve_dtype(self):
@@ -167,3 +77,15 @@ class TestTransform:
         # Checking if the dtype of "a" and "b" are int8 and float16 respectively after imputation
         assert df["a"].dtype == "int8"
         assert df["b"].dtype == "float16"
+
+
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
+
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ArbitraryImputer"

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -8,50 +10,40 @@ import tests.test_data as d
 from tests.base_tests import (
     ColumnStrListInitTests,
     GenericFitTests,
-    GenericTransformTests,
     OtherBaseBehaviourTests,
 )
-from tubular.imputers import BaseImputer
 
 
-class BaseImputerTransformTests(GenericTransformTests):
-    def test_not_fitted_error_raised(self):
-        df = pd.DataFrame(
-            {
-                "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
-                "b": ["a", "b", "c", "d", "e", "f", np.nan],
-                "c": ["a", "b", "c", "d", "e", "f", np.nan],
-            },
+class GenericImputerTransformTests:
+    def test_not_fitted_error_raised(self, initialized_transformers):
+        if initialized_transformers[self.transformer_name].FITS:
+            df = pd.DataFrame(
+                {
+                    "a": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                    "b": ["a", "b", "c", "d", "e", "f", np.nan],
+                    "c": ["a", "b", "c", "d", "e", "f", np.nan],
+                },
+            )
+
+            with pytest.raises(NotFittedError):
+                initialized_transformers[self.transformer_name].transform(df)
+
+    def test_impute_value_unchanged(self, initialized_transformers):
+        """Test that self.impute_value is unchanged after transform."""
+        df = d.create_df_1()
+
+        transformer = initialized_transformers[self.transformer_name]
+        transformer.impute_values_ = {"a": 1}
+
+        impute_values = deepcopy(transformer.impute_values_)
+
+        transformer.transform(df)
+
+        ta.classes.test_object_attributes(
+            obj=transformer,
+            expected_attributes={"impute_values_": impute_values},
+            msg="impute_values_ changed in transform",
         )
-
-        x = BaseImputer(columns=["b", "c"])
-
-        with pytest.raises(NotFittedError):
-            x.transform(df)
-
-
-class TestInit(ColumnStrListInitTests):
-    """Generic tests for transformer.init()."""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "BaseImputer"
-
-
-class TestFit(GenericFitTests):
-    """Generic tests for transformer.fit()"""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "BaseTransformer"
-
-
-class TestTransform(BaseImputerTransformTests):
-    """Tests for BaseImputer.transform."""
-
-    @classmethod
-    def setup_class(cls):
-        cls.transformer_name = "BaseTransformer"
 
     def expected_df_1():
         """Expected output of test_expected_output_1."""
@@ -99,54 +91,83 @@ class TestTransform(BaseImputerTransformTests):
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_2(), expected_df_1()),
     )
-    def test_expected_output_1(self, df, expected):
+    def test_expected_output_1(self, df, expected, initialized_transformers):
         """Test that transform is giving the expected output when applied to float column."""
-        x1 = BaseImputer(columns="a")
+        x1 = initialized_transformers[self.transformer_name]
         x1.impute_values_ = {"a": 7}
+        x1.columns = ["a"]
 
         df_transformed = x1.transform(df)
 
         ta.equality.assert_equal_dispatch(
             expected=expected,
             actual=df_transformed,
-            msg="ArbitraryImputer transform col a",
+            msg=f"Error from {self.transformer_name} transform col a",
         )
 
     @pytest.mark.parametrize(
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_2(), expected_df_2()),
     )
-    def test_expected_output_2(self, df, expected):
+    def test_expected_output_2(self, df, expected, initialized_transformers):
         """Test that transform is giving the expected output when applied to object column."""
-        x1 = BaseImputer(columns=["b"])
+        x1 = initialized_transformers[self.transformer_name]
 
         x1.impute_values_ = {"b": "g"}
+        x1.columns = ["b"]
 
         df_transformed = x1.transform(df)
 
         ta.equality.assert_equal_dispatch(
             expected=expected,
             actual=df_transformed,
-            msg="ArbitraryImputer transform col b",
+            msg=f"Error from {self.transformer_name} transform col b",
         )
 
     @pytest.mark.parametrize(
         ("df", "expected"),
         ta.pandas.adjusted_dataframe_params(d.create_df_2(), expected_df_3()),
     )
-    def test_expected_output_3(self, df, expected):
+    def test_expected_output_3(self, df, expected, initialized_transformers):
         """Test that transform is giving the expected output when applied to object and categorical columns."""
-        x1 = BaseImputer(columns=["b", "c"])
+        x1 = initialized_transformers[self.transformer_name]
 
         x1.impute_values_ = {"b": "g", "c": "f"}
+        x1.columns = ["b", "c"]
+        # bit of a hack to make this work nicely for arbitrary imputer
+        x1.impute_value = "f"
 
         df_transformed = x1.transform(df)
 
         ta.equality.assert_equal_dispatch(
             expected=expected,
             actual=df_transformed,
-            msg="ArbitraryImputer transform col b, c",
+            msg=f"Error from {self.transformer_name} transform col b, c",
         )
+
+
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseImputer"
+
+
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseImputer"
+
+
+class TestTransform(GenericImputerTransformTests):
+    """Tests for BaseImputer.transform."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseImputer"
 
 
 class TestOtherBaseBehaviour(OtherBaseBehaviourTests):

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -4,71 +4,46 @@ import pytest
 import test_aide as ta
 
 import tests.test_data as d
-import tubular
+from tests.base_tests import (
+    ColumnStrListInitTests,
+    GenericFitTests,
+    GenericTransformTests,
+    OtherBaseBehaviourTests,
+)
+from tests.imputers.test_BaseImputer import GenericImputerTransformTests
 from tubular.imputers import ModeImputer
 
 
-class TestInit:
-    """Tests for ModeImputer.init()."""
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
 
-    def test_super_init_called(self, mocker):
-        """Test that init calls BaseTransformer.init."""
-        expected_call_args = {
-            0: {"args": (), "kwargs": {"columns": None, "verbose": True}},
-        }
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ModeImputer"
 
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            ModeImputer(columns=None, verbose=True)
+    def test_weight_value_type_error(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+    ):
+        """Test that an exception is raised if weight is not a str."""
 
-    @pytest.mark.parametrize("weight", (0, ["a"], {"a": 10}))
-    def test_weight_arg_errors(self, weight):
-        """Test that appropriate errors are thrown for bad weight arg."""
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weight"] = 1
+
         with pytest.raises(
             ValueError,
-            match="ModeImputer: weight should be a string or None",
+            match="weight should be a string or None",
         ):
-            ModeImputer(columns=["s"], weight=weight)
+            uninitialized_transformers[self.transformer_name](**args)
 
 
-class TestFit:
-    """Tests for ModeImputer.fit()."""
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
 
-    def test_super_fit_called(self, mocker):
-        """Test that fit calls BaseTransformer.fit."""
-        df = d.create_df_3()
-
-        x = ModeImputer(columns=["a", "b", "c"])
-
-        expected_call_args = {0: {"args": (d.create_df_3(), None), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "fit",
-            expected_call_args,
-        ):
-            x.fit(df)
-
-    def test_check_weights_column_called(self, mocker):
-        """Test that fit calls BaseTransformer.check_weights_column - when weights are used."""
-        df = d.create_df_9()
-
-        x = ModeImputer(columns=["a", "b"], weight="c")
-
-        expected_call_args = {0: {"args": (d.create_df_9(), "c"), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "check_weights_column",
-            expected_call_args,
-        ):
-            x.fit(df)
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ModeImputer"
 
     def test_learnt_values(self):
         """Test that the impute values learnt during fit are expected."""
@@ -111,54 +86,6 @@ class TestFit:
             msg="impute_values_ attribute",
         )
 
-    def test_fit_returns_self(self):
-        """Test fit returns self?."""
-        df = d.create_df_1()
-
-        x = ModeImputer(columns="a")
-
-        x_fitted = x.fit(df)
-
-        assert x_fitted is x, "Returned value from ModeImputer.fit not as expected."
-
-    def test_fit_returns_self_weighted(self):
-        """Test fit returns self?."""
-        df = d.create_df_9()
-
-        x = ModeImputer(columns="a", weight="c")
-
-        x_fitted = x.fit(df)
-
-        assert x_fitted is x, "Returned value from ModeImputer.fit not as expected."
-
-    def test_fit_not_changing_data(self):
-        """Test fit does not change X."""
-        df = d.create_df_1()
-
-        x = ModeImputer(columns="a")
-
-        x.fit(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=d.create_df_1(),
-            actual=df,
-            msg="Check X not changing during fit",
-        )
-
-    def test_fit_not_changing_data_weighted(self):
-        """Test fit does not change X - when weights are used."""
-        df = d.create_df_9()
-
-        x = ModeImputer(columns="a", weight="c")
-
-        x.fit(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=d.create_df_9(),
-            actual=df,
-            msg="Check X not changing during fit",
-        )
-
     def expected_df_nan():
         return pd.DataFrame({"a": ["NaN", "NaN", "NaN"], "b": [None, None, None]})
 
@@ -184,176 +111,21 @@ class TestFit:
             x.fit(df)
 
 
-class TestTransform:
-    """Tests for ModeImputer.transform()."""
+class TestTransform(GenericTransformTests, GenericImputerTransformTests):
+    """Tests for transformer.transform."""
 
-    def expected_df_1():
-        """Expected output for test_nulls_imputed_correctly."""
-        df = pd.DataFrame(
-            {
-                "a": [1, 2, 3, 4, 5, 6, np.nan],
-                "b": [1, 2, 3, np.nan, 7, 8, 9],
-                "c": [np.nan, 1, 2, 3, -4, -5, -6],
-            },
-        )
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ModeImputer"
 
-        for col in ["a", "b", "c"]:
-            df.loc[df[col].isna(), col] = df[col].mode()[0]
 
-        return df
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
 
-    def expected_df_2():
-        """Expected output for test_nulls_imputed_correctly_2."""
-        df = pd.DataFrame(
-            {
-                "a": [1, 2, 3, 4, 5, 6, np.nan],
-                "b": [1, 2, 3, np.nan, 7, 8, 9],
-                "c": [np.nan, 1, 2, 3, -4, -5, -6],
-            },
-        )
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
 
-        for col in ["a"]:
-            df.loc[df[col].isna(), col] = df[col].mode()[0]
-
-        return df
-
-    def expected_df_3():
-        """Expected output for test_nulls_imputed_correctly_3."""
-        df = d.create_df_9()
-
-        for col in ["a"]:
-            df.loc[df[col].isna(), col] = 6
-
-        return df
-
-    def test_check_is_fitted_called(self, mocker):
-        """Test that BaseTransformer check_is_fitted called."""
-        df = d.create_df_1()
-
-        x = ModeImputer(columns="a")
-
-        x.fit(df)
-
-        expected_call_args = {0: {"args": (["impute_values_"],), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "check_is_fitted",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    def test_super_transform_called(self, mocker):
-        """Test that BaseTransformer.transform called."""
-        df = d.create_df_1()
-
-        x = ModeImputer(columns="a")
-
-        x.fit(df)
-
-        expected_call_args = {0: {"args": (d.create_df_1(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "transform",
-            expected_call_args,
-        ):
-            x.transform(df)
-
-    @pytest.mark.parametrize(
-        ("df", "expected"),
-        ta.pandas.adjusted_dataframe_params(d.create_df_3(), expected_df_1()),
-    )
-    def test_nulls_imputed_correctly(self, df, expected):
-        """Test missing values are filled with the correct values."""
-        x = ModeImputer(columns=["a", "b", "c"])
-
-        # set the impute values dict directly rather than fitting x on df so test works with helpers
-        x.impute_values_ = {"a": 1.0, "b": 1.0, "c": -6.0}
-
-        df_transformed = x.transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=expected,
-            actual=df_transformed,
-            msg="Check nulls filled correctly in transform",
-        )
-
-    @pytest.mark.parametrize(
-        ("df", "expected"),
-        ta.pandas.adjusted_dataframe_params(d.create_df_3(), expected_df_2()),
-    )
-    def test_nulls_imputed_correctly_2(self, df, expected):
-        """Test missing values are filled with the correct values - and unrelated columns are not changed."""
-        x = ModeImputer(columns=["a"])
-
-        # set the impute values dict directly rather than fitting x on df so test works with helpers
-        x.impute_values_ = {"a": 1.0}
-
-        df_transformed = x.transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=expected,
-            actual=df_transformed,
-            msg="Check nulls filled correctly in transform",
-        )
-
-    @pytest.mark.parametrize(
-        ("df", "expected"),
-        ta.pandas.row_by_row_params(d.create_df_9(), expected_df_3())
-        + ta.pandas.index_preserved_params(d.create_df_9(), expected_df_3()),
-    )
-    def test_nulls_imputed_correctly_3(self, df, expected):
-        """Test missing values are filled with the correct values - and unrelated columns are not changed
-        (when weight is used).
-        """
-        x = ModeImputer(columns=["a"], weight="c")
-
-        # set the impute values dict directly rather than fitting x on df so test works with helpers
-        x.impute_values_ = {"a": 6}
-
-        df_transformed = x.transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=expected,
-            actual=df_transformed,
-            msg="Check nulls filled correctly in transform",
-        )
-
-    def test_learnt_values_not_modified(self):
-        """Test that the impute_values_ from fit are not changed in transform."""
-        df = d.create_df_3()
-
-        x = ModeImputer(columns=["a", "b", "c"])
-
-        x.fit(df)
-
-        x2 = ModeImputer(columns=["a", "b", "c"])
-
-        x2.fit_transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=x.impute_values_,
-            actual=x2.impute_values_,
-            msg="Impute values not changed in transform",
-        )
-
-    def test_learnt_values_not_modified_weights(self):
-        """Test that the impute_values_ from fit are not changed in transform - when using weights."""
-        df = d.create_df_9()
-
-        x = ModeImputer(columns=["a", "b"], weight="c")
-
-        x.fit(df)
-
-        x2 = ModeImputer(columns=["a", "b"], weight="c")
-
-        x2.fit_transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=x.impute_values_,
-            actual=x2.impute_values_,
-            msg="Impute values not changed in transform",
-        )
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "ModeImputer"

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -61,6 +61,17 @@ def create_df_2():
     return df
 
 
+def create_df_3():
+    """Create simple DataFrame to use in other tests."""
+    return pd.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, np.nan],
+            "b": [1, 2, 3, np.nan, 7, 8, 9],
+            "c": [np.nan, 1, 2, 3, -4, -5, -6],
+        },
+    )
+
+
 def create_df_4():
     """Create simple DataFrame to use in other tests."""
     df = pd.DataFrame(
@@ -74,17 +85,6 @@ def create_df_4():
     df["c"] = df["c"].astype("category")
 
     return df
-
-
-def create_df_3():
-    """Create simple DataFrame to use in other tests."""
-    return pd.DataFrame(
-        {
-            "a": [1, 2, 3, 4, 5, 6, np.nan],
-            "b": [1, 2, 3, np.nan, 7, 8, 9],
-            "c": [np.nan, 1, 2, 3, -4, -5, -6],
-        },
-    )
 
 
 def create_df_5():

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -17,6 +17,8 @@ class BaseImputer(BaseTransformer):
     Other imputers in this module should inherit from this class.
     """
 
+    FITS = False
+
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Impute missing values with median values calculated from fit method.
 
@@ -60,16 +62,14 @@ class ArbitraryImputer(BaseImputer):
         Value to impute nulls with.
     """
 
+    FITS = False
+
     def __init__(
         self,
         impute_value: float | str,
-        columns: str | list[str] | None = None,
+        columns: str | list[str],
         **kwargs: dict[str, bool],
     ) -> None:
-        if columns is None:
-            msg = f"{self.classname()}: columns must be specified in init for ArbitraryImputer"
-            raise ValueError(msg)
-
         super().__init__(columns=columns, **kwargs)
 
         if (
@@ -82,6 +82,9 @@ class ArbitraryImputer(BaseImputer):
 
         self.impute_values_ = {}
         self.impute_value = impute_value
+
+        for c in self.columns:
+            self.impute_values_[c] = self.impute_value
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Impute missing values with the supplied impute_value.
@@ -113,9 +116,6 @@ class ArbitraryImputer(BaseImputer):
                 X[c] = X[c].cat.add_categories(
                     self.impute_value,
                 )  # add new category
-            self.impute_values_[
-                c
-            ] = self.impute_value  # updating impute_values_ attribute
 
         # Calling the BaseImputer's transform method to impute the values
         X_transformed = super().transform(X)


### PR DESCRIPTION
Quick check of changes to ModeImputer test - I think I need to add the functions removed from the 'fit' section of the mode imputer tests to the TestFit clas in 'test_BaseImputer' as these will apply to other imputers I think?