### PR TITLE
225 bring basenominaltransformer in line with new testing setup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Changed
 - Refactored ArbitraryImputer and BaseImputer tests in new format.
 - Refactored MedianImputer tests in new format.
 - Replaced occurrences of pd.Dataframe.drop() with del statement to speed up tubular. Note that no additional unit testing has been done for copy=False as this release is scheduled to remove copy. 
+- Refactored BaseNominalTransformer tests in new format & moved its logic to the transform method.
 
 Removed
 ^^^^^^^

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ def minimal_attribute_dict():
             "dtype": str,
         },
         "BaseNominalTransformer": {
-            "columns": ["a"],
+            "columns": ["b"],
         },
         "NominalToIntegerTransformer": {
             "columns": ["b"],

--- a/tests/nominal/test_BaseNominalTransformer.py
+++ b/tests/nominal/test_BaseNominalTransformer.py
@@ -1,22 +1,41 @@
+import re
+
+import pandas as pd
 import pytest
+from sklearn.exceptions import NotFittedError
 
 import tests.test_data as d
-from tubular.nominal import BaseNominalTransformer
+from tests.base_tests import (
+    ColumnStrListInitTests,
+    GenericFitTests,
+    GenericTransformTests,
+    OtherBaseBehaviourTests,
+)
 
 
-class TestInit:
-    """Test for BaseNominalTransformer object.
-    Currently nothing to test."""
+# The first part of this file builds out the tests for BaseNominalTransformer so that they can be
+# imported into other test files (by not starting the class name with Test)
+# The second part actually calls these tests (along with all other require tests) for the BaseNominalTransformer
+class GenericBaseNominalTransformerTests:
+    """
+    Tests for BaseNominalTransformer.transform().
+    Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
+    """
 
+    def test_not_fitted_error_raised(self, initialized_transformers):
+        if initialized_transformers[self.transformer_name].FITS:
+            df = d.create_df_1()
 
-class TestCheckMappableRows:
-    """Tests for the BaseNominalTransformer.check_mappable_rows method."""
+            with pytest.raises(NotFittedError):
+                initialized_transformers[self.transformer_name].transform(df)
 
-    def test_exception_raised(self):
+    def test_exception_raised(self, initialized_transformers):
         """Test an exception is raised if non-mappable rows are present in X."""
         df = d.create_df_1()
 
-        x = BaseNominalTransformer(columns=["a", "b"])
+        x = initialized_transformers[self.transformer_name]
+
+        x.fit(df)
 
         x.mappings = {
             "a": {1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7},
@@ -27,4 +46,73 @@ class TestCheckMappableRows:
             ValueError,
             match="BaseNominalTransformer: nulls would be introduced into column b from levels not present in mapping",
         ):
-            x.check_mappable_rows(df)
+            x.transform(df)
+
+    def test_original_df_not_updated(self, initialized_transformers):
+        """Test that the original dataframe is not transformed when transform method used."""
+
+        df = d.create_df_1()
+
+        x = initialized_transformers[self.transformer_name]
+
+        x = x.fit(df)
+
+        x.mappings = {"b": {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6}}
+
+        _ = x.transform(df)
+
+        pd.testing.assert_frame_equal(df, d.create_df_1())
+
+    def test_no_rows_error(self, initialized_transformers):
+        """Test an error is raised if X has no rows."""
+        df = d.create_df_1()
+
+        x = initialized_transformers[self.transformer_name]
+
+        x = x.fit(df)
+
+        x.mappings = {"b": {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6}}
+
+        df = pd.DataFrame(columns=["a", "b", "c"])
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(f"{self.transformer_name}: X has no rows; (0, 3)"),
+        ):
+            x.transform(df)
+
+
+class TestInit(ColumnStrListInitTests):
+    """Generic tests for transformer.init()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseNominalTransformer"
+
+
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseNominalTransformer"
+
+
+class TestTransform(GenericBaseNominalTransformerTests, GenericTransformTests):
+    """Tests for BaseImputer.transform."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseNominalTransformer"
+
+
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
+
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "BaseNominalTransformer"

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -290,7 +290,7 @@ class TestTransform:
 
         with ta.functions.assert_function_call(
             mocker,
-            tubular.nominal.BaseNominalTransformer,
+            tubular.base.BaseTransformer,
             "transform",
             expected_call_args,
             return_value=d.create_df_5(),

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -1091,7 +1091,7 @@ class TestTransform:
             x.transform(X=[1, 2, 3, 4, 5, 6])
 
     def test_super_transform_called(self, mocker):
-        """Test that BaseTransformer.transform called."""
+        """Test that BaseNominalTransformer.transform called."""
         df = d.create_MeanResponseTransformer_test_df()
 
         x = MeanResponseTransformer(columns="b")
@@ -1104,7 +1104,7 @@ class TestTransform:
 
         with ta.functions.assert_function_call(
             mocker,
-            tubular.base.BaseTransformer,
+            tubular.nominal.BaseNominalTransformer,
             "transform",
             expected_call_args,
             return_value=d.create_MeanResponseTransformer_test_df(),

--- a/tests/nominal/test_NominalToIntegerTransformer.py
+++ b/tests/nominal/test_NominalToIntegerTransformer.py
@@ -149,14 +149,14 @@ class TestTransform:
             x.transform(X=[1, 2, 3, 4, 5, 6])
 
     def test_super_transform_called(self, mocker):
-        """Test that BaseTransformer.transform called."""
+        """Test that BaseNominalTransformer.transform called."""
         df = d.create_df_1()
 
         x = NominalToIntegerTransformer(columns="a")
 
         x.fit(df)
 
-        expected_call_args = {0: {"args": (d.create_df_1(),), "kwargs": {}}}
+        expected_call_args = {0: {"args": (x, d.create_df_1()), "kwargs": {}}}
 
         with ta.functions.assert_function_call(
             mocker,

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -234,27 +234,6 @@ class TestTransform:
         ):
             x.transform(df)
 
-    def test_check_is_fitted_first_call(self, mocker):
-        """Test the calls to BaseTransformer check_is_fitted."""
-        df = d.create_df_1()
-
-        x = OneHotEncodingTransformer(columns="b")
-
-        x.fit(df)
-
-        expected_call_args = {
-            0: {"args": (["separator"],), "kwargs": {}},
-            1: {"args": (["drop_original"],), "kwargs": {}},
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "check_is_fitted",
-            expected_call_args,
-        ):
-            x.transform(df)
-
     def test_non_numeric_column_error_1(self):
         """Test that transform will raise an error if a column to transform has nulls."""
         df_train = d.create_df_1()

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -13,75 +13,75 @@ class TestInit:
     """Tests for OneHotEncodingTransformer.init()."""
 
     def test_super_init_called(self, mocker):
-        """Test that init calls BaseNominalTransformer.init.
+        """Test that init calls BaseTransformer.init.
 
-        Note, not using ta.functions.assert_function_call for this as it does not handle self being passed to BaseNominalTransformer.init.
+        Note, not using ta.functions.assert_function_call for this as it does not handle self being passed to BaseTransformer.init.
         """
         expected_keyword_args = {"columns": None, "verbose": True, "copy": None}
 
-        mocker.patch("tubular.nominal.BaseNominalTransformer.__init__")
+        mocker.patch("tubular.base.BaseTransformer.__init__")
 
         x = OneHotEncodingTransformer(columns=None, verbose=True)
 
         assert (
-            tubular.nominal.BaseNominalTransformer.__init__.call_count == 1
-        ), f"Not enough calls to BaseNominalTransformer.__init__ -\n  Expected: 1\n  Actual: {tubular.nominal.BaseNominalTransformer.__init__.call_count}"
+            tubular.base.BaseTransformer.__init__.call_count == 1
+        ), f"Not enough calls to BaseTransformer.__init__ -\n  Expected: 1\n  Actual: {tubular.base.BaseTransformer.__init__.call_count}"
 
-        call_args = tubular.nominal.BaseNominalTransformer.__init__.call_args_list[0]
+        call_args = tubular.base.BaseTransformer.__init__.call_args_list[0]
         call_pos_args = call_args[0]
         call_kwargs = call_args[1]
 
         ta.equality.assert_equal_dispatch(
             expected=expected_keyword_args,
             actual=call_kwargs,
-            msg="kwargs for BaseNominalTransformer.__init__ in OneHotEncodingTransformer.init",
+            msg="kwargs for BaseTransformer.__init__ in OneHotEncodingTransformer.init",
         )
 
         assert (
             len(call_pos_args) == 1
-        ), f"Unepxected number of positional args in BaseNominalTransformer.__init__ call -\n  Expected: 1\n  Actual: {len(call_pos_args)}"
+        ), f"Unepxected number of positional args in BaseTransformer.__init__ call -\n  Expected: 1\n  Actual: {len(call_pos_args)}"
 
         assert (
             call_pos_args[0] is x
-        ), f"Unexpected positional arg (self) in BaseNominalTransformer.__init__ call -\n  Expected: self\n  Actual: {call_pos_args[0]}"
+        ), f"Unexpected positional arg (self) in BaseTransformer.__init__ call -\n  Expected: self\n  Actual: {call_pos_args[0]}"
 
 
 class TestFit:
     """Tests for OneHotEncodingTransformer.fit()."""
 
-    def test_base_nominal_transformer_fit_called(self, mocker):
-        """Test that fit calls BaseNominalTransformer.fit."""
+    def test_base_transformer_fit_called(self, mocker):
+        """Test that fit calls BaseTransformer.fit."""
         expected_keyword_args = {"X": d.create_df_1(), "y": None}
 
         df = d.create_df_1()
 
         x = OneHotEncodingTransformer(columns="b")
 
-        mocker.patch("tubular.nominal.BaseNominalTransformer.fit")
+        mocker.patch("tubular.base.BaseTransformer.fit")
 
         x.fit(df)
 
         assert (
-            tubular.nominal.BaseNominalTransformer.fit.call_count == 1
-        ), f"Not enough calls to BaseNominalTransformer.fit -\n  Expected: 1\n  Actual: {tubular.nominal.BaseNominalTransformer.fit.call_count}"
+            tubular.base.BaseTransformer.fit.call_count == 1
+        ), f"Not enough calls to BaseTransformer.fit -\n  Expected: 1\n  Actual: {tubular.base.BaseTransformer.fit.call_count}"
 
-        call_args = tubular.nominal.BaseNominalTransformer.fit.call_args_list[0]
+        call_args = tubular.base.BaseTransformer.fit.call_args_list[0]
         call_pos_args = call_args[0]
         call_kwargs = call_args[1]
 
         ta.equality.assert_equal_dispatch(
             expected=expected_keyword_args,
             actual=call_kwargs,
-            msg="kwargs for BaseNominalTransformer.fit in OneHotEncodingTransformer.init",
+            msg="kwargs for BaseTransformer.fit in OneHotEncodingTransformer.init",
         )
 
         assert (
             len(call_pos_args) == 1
-        ), f"Unepxected number of positional args in BaseNominalTransformer.fit call -\n  Expected: 1\n  Actual: {len(call_pos_args)}"
+        ), f"Unepxected number of positional args in BaseTransformer.fit call -\n  Expected: 1\n  Actual: {len(call_pos_args)}"
 
         assert (
             call_pos_args[0] is x
-        ), f"Unexpected positional arg (self) in BaseNominalTransformer.fit call -\n  Expected: self\n  Actual: {call_pos_args[0]}"
+        ), f"Unexpected positional arg (self) in BaseTransformer.fit call -\n  Expected: self\n  Actual: {call_pos_args[0]}"
 
     def test_one_hot_encoder_fit_called(self, mocker):
         """Test that fit calls OneHotEncoder.fit."""
@@ -287,7 +287,7 @@ class TestTransform:
 
         assert (
             tubular.base.BaseTransformer.transform.call_count == 1
-        ), f"Not enough calls to BaseTransformer.transform -\n  Expected: 1\n  Actual: {tubular.nominal.BaseNominalTransformer.transform.call_count}"
+        ), f"Not enough calls to BaseTransformer.transform -\n  Expected: 1\n  Actual: {tubular.base.BaseTransformer.transform.call_count}"
 
         call_args = tubular.base.BaseTransformer.transform.call_args_list[0]
         call_pos_args = call_args[0]

--- a/tests/nominal/test_OneHotEncodingTransformer.py
+++ b/tests/nominal/test_OneHotEncodingTransformer.py
@@ -270,8 +270,8 @@ class TestTransform:
         ):
             x.transform(df_test)
 
-    def test_base_nominal_transformer_transform_called(self, mocker):
-        """Test that BaseNominalTransformer.transform called."""
+    def test_base_transformer_transform_called(self, mocker):
+        """Test that BaseTransformer.transform called."""
         df = d.create_df_1()
 
         x = OneHotEncodingTransformer(columns="b")
@@ -279,41 +279,41 @@ class TestTransform:
         x.fit(df)
 
         mocker.patch(
-            "tubular.nominal.BaseNominalTransformer.transform",
+            "tubular.base.BaseTransformer.transform",
             return_value=d.create_df_1(),
         )
 
         x.transform(df)
 
         assert (
-            tubular.nominal.BaseNominalTransformer.transform.call_count == 1
-        ), f"Not enough calls to BaseNominalTransformer.transform -\n  Expected: 1\n  Actual: {tubular.nominal.BaseNominalTransformer.transform.call_count}"
+            tubular.base.BaseTransformer.transform.call_count == 1
+        ), f"Not enough calls to BaseTransformer.transform -\n  Expected: 1\n  Actual: {tubular.nominal.BaseNominalTransformer.transform.call_count}"
 
-        call_args = tubular.nominal.BaseNominalTransformer.transform.call_args_list[0]
+        call_args = tubular.base.BaseTransformer.transform.call_args_list[0]
         call_pos_args = call_args[0]
         call_kwargs = call_args[1]
 
         ta.equality.assert_equal_dispatch(
             expected={},
             actual=call_kwargs,
-            msg="kwargs for BaseNominalTransformer.transform in OneHotEncodingTransformer.init",
+            msg="kwargs for BaseTransformer.transform in OneHotEncodingTransformer.init",
         )
 
         expected_pos_args = (x, d.create_df_1())
 
         assert (
             len(call_pos_args) == 2
-        ), f"Unepxected number of positional args in BaseNominalTransformer.transform call -\n  Expected: 2\n  Actual: {len(call_pos_args)}"
+        ), f"Unepxected number of positional args in BaseTransformer.transform call -\n  Expected: 2\n  Actual: {len(call_pos_args)}"
 
         ta.equality.assert_frame_equal_msg(
             expected=expected_pos_args[1],
             actual=call_pos_args[1],
-            msg_tag="X positional arg in BaseNominalTransformer.transform call",
+            msg_tag="X positional arg in BaseTransformer.transform call",
         )
 
         assert (
             expected_pos_args[0] == call_pos_args[0]
-        ), "self positional arg in BaseNominalTransformer.transform call"
+        ), "self positional arg in BaseTransformer.transform call"
 
     def test_one_hot_encoder_transform_called(self, mocker):
         """Test that OneHotEncoder.transform called."""

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1042,7 +1042,7 @@ class OrdinalEncoderTransformer(BaseNominalTransformer, BaseMappingTransformMixi
         return BaseMappingTransformMixin.transform(self, X)
 
 
-class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
+class OneHotEncodingTransformer(BaseTransformer, OneHotEncoder):
     """Transformer to convert cetegorical variables into dummy columns.
 
     Extends the sklearn OneHotEncoder class to provide easy renaming of dummy columns.
@@ -1091,7 +1091,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
         dtype: np.int8 = np.int8,
         **kwargs: dict[str, bool],
     ) -> None:
-        BaseNominalTransformer.__init__(
+        BaseTransformer.__init__(
             self,
             columns=columns,
             verbose=verbose,
@@ -1124,7 +1124,7 @@ class OneHotEncodingTransformer(BaseNominalTransformer, OneHotEncoder):
             Ignored. This parameter exists only for compatibility with sklearn.pipeline.Pipeline.
 
         """
-        BaseNominalTransformer.fit(self, X=X, y=y)
+        BaseTransformer.fit(self, X=X, y=y)
 
         # Check for nulls
         for c in self.columns:

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -28,7 +28,6 @@ class BaseNominalTransformer(BaseTransformer):
             the mapping dict in mappings[c].
 
         """
-        self.columns_check(X)
         self.check_is_fitted(["mappings"])
 
         for c in self.columns:
@@ -54,10 +53,12 @@ class BaseNominalTransformer(BaseTransformer):
 
         """
 
+        # specify which class to prevent additional inheritance calls
+        X = BaseTransformer.transform(self, X)
+
         self.check_mappable_rows(X)
 
-        # specify which class to prevent additional inheritance calls
-        return BaseTransformer.transform(self, X)
+        return X
 
 
 class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMixin):

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -1200,8 +1200,6 @@ class OneHotEncodingTransformer(BaseTransformer, OneHotEncoder):
             the output X.
 
         """
-        self.check_is_fitted(["separator"])
-        self.check_is_fitted(["drop_original"])
 
         X = BaseTransformer.transform(self, X)
 


### PR DESCRIPTION
Link to issue: https://github.com/lvgig/tubular/issues/225
Update BaseNominalTransformer tests to be in line with testing refactor: https://github.com/lvgig/tubular/issues/150
* Added FITS attribute in line with imputers: https://github.com/lvgig/tubular/pull/212
* Moved check_mappable_rows to transform method
* Updated child classes & their tests to account for above refactoring changes
* Updated BaseNominalTransformer tests in line with testing refactor