### PR TITLE
Automated weights column checks through Mixin Class and capturing shared weight tests in generic test classes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,9 +24,11 @@ Added
 - Inheritable tests for generic base behaviours for base transformer in `base_tests.py`, with fixtures to allow for this in `conftest.py`
 - Split existing input check into two better defined checks for TwoColumnOperatorTransformer `#183 <https://github.com/lvgig/tubular/pull/183>`_
 - Created unit tests for checking column type and size `#183 <https://github.com/lvgig/tubular/pull/183>`_
+- Automated weights column checks through a mixin class and captured common weight tests in generic test classes for weighted transformers
 
 Changed
 ^^^^^^^
+- Standardised naming of weight arg across transformers 
 - Update DataFrameMethodTransformer tests to have inheritable init class that can be used by othe test files.
 - Moved BaseTransformer, DataFrameMethodTransformer, BaseMappingTransformer, BaseMappingTransformerMixin, CrossColumnMappingTransformer and Mapping Transformer over to the new testing framework.
 - Refactored MappingTransformer by removing redundant init method.

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -120,20 +120,20 @@ class WeightColumnInitTests(GenericInitTests):
     Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
     """
 
-    @pytest.mark.parametrize("weight", (0, ["a"], {"a": 10}))
+    @pytest.mark.parametrize("weights_column", (0, ["a"], {"a": 10}))
     def test_weight_arg_errors(
         self,
         uninitialized_transformers,
         minimal_attribute_dict,
-        weight,
+        weights_column,
     ):
         """Test that appropriate errors are throw for bad weight arg."""
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weight"] = weight
+        args["weights_column"] = weights_column
 
         with pytest.raises(
             TypeError,
-            match="weight should be str or None",
+            match="weights_column should be str or None",
         ):
             uninitialized_transformers[self.transformer_name](**args)
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -423,16 +423,6 @@ class WeightColumnFitTests(GenericFitTests):
                 r"weight column must be numeric.",
                 "b",
             ),
-            (
-                pd.DataFrame({"a": [1, 2], "b": [-1, 0]}),
-                r"weight column must be positive",
-                "b",
-            ),
-            (
-                pd.DataFrame({"a": [1, 2], "b": [np.nan, 0]}),
-                r"weight column must be non-null",
-                "b",
-            ),
         ]
 
     @pytest.mark.parametrize("df, error, col", get_df_error_combos())
@@ -444,7 +434,7 @@ class WeightColumnFitTests(GenericFitTests):
         uninitialized_transformers,
         minimal_attribute_dict,
     ):
-        """Test an error is raised if weight is not in X."""
+        """Test an error is raised if weight is not in X or weight is not numeric."""
 
         with pytest.raises(
             ValueError,

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -114,6 +114,30 @@ class ColumnStrListInitTests(GenericInitTests):
             uninitialized_transformers[self.transformer_name](**args)
 
 
+class WeightColumnInitTests(GenericInitTests):
+    """
+    Tests for BaseTransformer.init() behaviour specific to when a transformer takes accepts a weight column.
+    Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
+    """
+
+    @pytest.mark.parametrize("weight", (0, ["a"], {"a": 10}))
+    def test_weight_arg_errors(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+        weight,
+    ):
+        """Test that appropriate errors are throw for bad weight arg."""
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weight"] = weight
+
+        with pytest.raises(
+            TypeError,
+            match="weight should be str or None",
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
+
 class GenericFitTests:
     """
     Generic tests for transformer.fit().

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -263,6 +263,118 @@ class GenericFitTests:
             )
 
 
+class WeightColumnFitTests(GenericFitTests):
+    def test_fit_returns_self_weighted(
+        self,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test fit returns self?."""
+        df = d.create_df_9()
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weights_column"] = "c"
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        x_fitted = transformer.fit(df)
+
+        assert (
+            x_fitted is transformer
+        ), f"Returned value from {self.transformer_name}.fit not as expected."
+
+    def test_fit_not_changing_data_weighted(
+        self,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test fit does not change X - when weights are used."""
+        df = d.create_df_9()
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weights_column"] = "c"
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        transformer.fit(df)
+        ta.equality.assert_equal_dispatch(
+            expected=d.create_df_9(),
+            actual=df,
+            msg=f"X changed during fit for {self.transformer_name}",
+        )
+
+    @pytest.mark.parametrize(
+        "bad_weight_value, expected_message",
+        [
+            (np.nan, "weight column must be non-null"),
+            (np.inf, "weight column must not contain infinite values."),
+            (-np.inf, "weight column must be positive"),
+            (-1, "weight column must be positive"),
+        ],
+    )
+    def test_bad_values_in_weights_error(
+        self,
+        bad_weight_value,
+        expected_message,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test that an exception is raised if there are negative/nan/inf values in sample_weight."""
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weights_column"] = "w"
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        df = pd.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "w": [1, 1, bad_weight_value],
+            },
+        )
+
+        with pytest.raises(ValueError, match=expected_message):
+            transformer.fit(df)
+
+    def get_df_error_combos():
+        return [
+            (
+                pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
+                r"weight col \(c\) is not present in columns of data",
+                "c",
+            ),
+            (
+                pd.DataFrame({"a": [1, 2], "b": ["a", "b"]}),
+                r"weight column must be numeric.",
+                "b",
+            ),
+            (
+                pd.DataFrame({"a": [1, 2], "b": [-1, 0]}),
+                r"weight column must be positive",
+                "b",
+            ),
+            (
+                pd.DataFrame({"a": [1, 2], "b": [np.nan, 0]}),
+                r"weight column must be non-null",
+                "b",
+            ),
+        ]
+
+    @pytest.mark.parametrize("df, error, col", get_df_error_combos())
+    def test_weight_not_in_X_error(self, df, error, col, uninitialized_transformers):
+        """Test an error is raised if weight is not in X."""
+
+        with pytest.raises(
+            ValueError,
+            match=error,
+        ):
+            # using check_weights_column method to test correct error is raised for transformers that use weights
+
+            uninitialized_transformers[self.transformer_name].check_weights_column(
+                df,
+                col,
+            )
+
+
 class GenericTransformTests:
     """
     Generic tests for transformer.transform().
@@ -464,64 +576,8 @@ class CombineXYTests:
         pd.testing.assert_frame_equal(result, expected_output)
 
 
-class CheckWeightsColumnTests:
-    """
-    tests for check_weights_column method.
-    Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
-    """
-
-    def get_df_error_combos():
-        return [
-            (
-                pd.DataFrame({"a": [1, 2], "b": [3, 4]}),
-                r"weight col \(c\) is not present in columns of data",
-                "c",
-            ),
-            (
-                pd.DataFrame({"a": [1, 2], "b": ["a", "b"]}),
-                r"weight column must be numeric.",
-                "b",
-            ),
-            (
-                pd.DataFrame({"a": [1, 2], "b": [-1, 0]}),
-                r"weight column must be positive",
-                "b",
-            ),
-            (
-                pd.DataFrame({"a": [1, 2], "b": [np.nan, 0]}),
-                r"weight column must be non-null",
-                "b",
-            ),
-        ]
-
-    @pytest.mark.parametrize("df, error, col", get_df_error_combos())
-    def test_weight_not_in_X_error(self, df, error, col, uninitialized_transformers):
-        """Test an error is raised if weight is not in X."""
-
-        with pytest.raises(
-            ValueError,
-            match=error,
-        ):
-            # using check_weights_column method to test correct error is raised for transformers that use weights
-            for transformer_name in [
-                "CappingTransformer",
-                "OutOfRangeNullTransformer",
-                "MedianImputer",
-                "MeanImputer",
-                "ModeImputer",
-                "GroupRareLevelsTransformer",
-                "MeanResponseTransformer",
-                "OrdinalEncoderTransformer",
-            ]:
-                uninitialized_transformers[transformer_name].check_weights_column(
-                    df,
-                    col,
-                )
-
-
 class OtherBaseBehaviourTests(
     ColumnsCheckTests,
-    CheckWeightsColumnTests,
     CombineXYTests,
 ):
     """

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -120,7 +120,6 @@ class ColumnStrListInitTests(GenericInitTests):
             uninitialized_transformers[self.transformer_name](**args)
 
 
-
 class WeightColumnInitTests(GenericInitTests):
     """
     Tests for BaseTransformer.init() behaviour specific to when a transformer takes accepts a weight column.
@@ -141,6 +140,9 @@ class WeightColumnInitTests(GenericInitTests):
         with pytest.raises(
             TypeError,
             match="weights_column should be str or None",
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
 
 class TwoColumnListInitTests(ColumnStrListInitTests):
     """
@@ -208,7 +210,6 @@ class TwoColumnListInitTests(ColumnStrListInitTests):
             match=re.escape(
                 f"{self.transformer_name}: new_col_name should be str",
             ),
-
         ):
             uninitialized_transformers[self.transformer_name](**args)
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -478,10 +478,21 @@ class CheckWeightsColumnTests:
             ValueError,
             match=error,
         ):
-            uninitialized_transformers[self.transformer_name].check_weights_column(
-                df,
-                col,
-            )
+            # using check_weights_column method to test correct error is raised for transformers that use weights
+            for transformer_name in [
+                "CappingTransformer",
+                "OutOfRangeNullTransformer",
+                "MedianImputer",
+                "MeanImputer",
+                "ModeImputer",
+                "GroupRareLevelsTransformer",
+                "MeanResponseTransformer",
+                "OrdinalEncoderTransformer",
+            ]:
+                uninitialized_transformers[transformer_name].check_weights_column(
+                    df,
+                    col,
+                )
 
 
 class OtherBaseBehaviourTests(

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -10,6 +10,7 @@ from tests.base_tests import (
     GenericFitTests,
     GenericInitTests,
     GenericTransformTests,
+    WeightColumnFitTests,
     WeightColumnInitTests,
 )
 from tubular.capping import BaseCappingTransformer
@@ -228,7 +229,7 @@ class GenericCappingInitTests(WeightColumnInitTests, GenericInitTests):
             uninitialized_transformers[self.transformer_name](**args)
 
 
-class GenericCappingFitTests(GenericFitTests):
+class GenericCappingFitTests(WeightColumnFitTests, GenericFitTests):
     """Tests for BaseCappingTransformer.fit()."""
 
     @classmethod
@@ -253,41 +254,6 @@ class GenericCappingFitTests(GenericFitTests):
         ):
             df = d.create_df_3()
 
-            transformer.fit(df)
-
-    @pytest.mark.parametrize(
-        "bad_weight_value, expected_message",
-        [
-            (np.nan, "weight column must be non-null"),
-            (np.inf, "weight column must not contain infinite values."),
-            (-np.inf, "weight column must be positive"),
-            (-1, "weight column must be positive"),
-        ],
-    )
-    def test_bad_values_in_weights_error(
-        self,
-        bad_weight_value,
-        expected_message,
-        minimal_attribute_dict,
-        uninitialized_transformers,
-    ):
-        """Test that an exception is raised if there are negative/nan/inf values in sample_weight."""
-
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["quantiles"] = {"a": [0.2, 0.9]}
-        args["capping_values"] = None
-        args["weights_column"] = "w"
-
-        transformer = uninitialized_transformers[self.transformer_name](**args)
-
-        df = pd.DataFrame(
-            {
-                "a": [1, 2, 3],
-                "w": [1, 1, bad_weight_value],
-            },
-        )
-
-        with pytest.raises(ValueError, match=expected_message):
             transformer.fit(df)
 
     def test_zero_total_weight_error(

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -21,6 +21,23 @@ class GenericCappingInitTests(GenericInitTests):
     def setup_class(cls):
         cls.transformer_name = "BaseCappingTransformer"
 
+    @pytest.mark.parametrize("weights_column", (0, ["a"], {"a": 10}))
+    def test_weight_arg_errors(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+        weights_column,
+    ):
+        """Test that appropriate errors are throw for bad weight arg."""
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weights_column"] = weights_column
+
+        with pytest.raises(
+            TypeError,
+            match="weights_column should be str or None",
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
     @pytest.mark.parametrize(
         "non_string, cap_type",
         [(1, "capping_values"), (True, "quantiles")],

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -255,13 +255,18 @@ class GenericCappingFitTests(GenericFitTests):
             transformer.fit(df)
 
     @pytest.mark.parametrize(
-        "bad_weight_value, issue",
-        [(np.nan, "null"), (np.inf, "inf"), (-np.inf, "inf"), (-1, "negative")],
+        "bad_weight_value, expected_message",
+        [
+            (np.nan, "weight column must be non-null"),
+            (np.inf, "weight column must not contain infinite values."),
+            (-np.inf, "weight column must be positive"),
+            (-1, "weight column must be positive"),
+        ],
     )
     def test_bad_values_in_weights_error(
         self,
         bad_weight_value,
-        issue,
+        expected_message,
         minimal_attribute_dict,
         uninitialized_transformers,
     ):
@@ -281,10 +286,7 @@ class GenericCappingFitTests(GenericFitTests):
             },
         )
 
-        with pytest.raises(
-            ValueError,
-            match=f"{self.transformer_name}: sample weights values cannot be {issue}",
-        ):
+        with pytest.raises(ValueError, match=expected_message):
             transformer.fit(df)
 
     def test_zero_total_weight_error(

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -10,33 +10,17 @@ from tests.base_tests import (
     GenericFitTests,
     GenericInitTests,
     GenericTransformTests,
+    WeightColumnInitTests,
 )
 from tubular.capping import BaseCappingTransformer
 
 
-class GenericCappingInitTests(GenericInitTests):
+class GenericCappingInitTests(WeightColumnInitTests, GenericInitTests):
     """Tests for BaseCappingTransformer.init()."""
 
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "BaseCappingTransformer"
-
-    @pytest.mark.parametrize("weights_column", (0, ["a"], {"a": 10}))
-    def test_weight_arg_errors(
-        self,
-        uninitialized_transformers,
-        minimal_attribute_dict,
-        weights_column,
-    ):
-        """Test that appropriate errors are throw for bad weight arg."""
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = weights_column
-
-        with pytest.raises(
-            TypeError,
-            match="weights_column should be str or None",
-        ):
-            uninitialized_transformers[self.transformer_name](**args)
 
     @pytest.mark.parametrize(
         "non_string, cap_type",

--- a/tests/capping/test_BaseCappingTransformer.py
+++ b/tests/capping/test_BaseCappingTransformer.py
@@ -256,32 +256,6 @@ class GenericCappingFitTests(WeightColumnFitTests, GenericFitTests):
 
             transformer.fit(df)
 
-    def test_zero_total_weight_error(
-        self,
-        minimal_attribute_dict,
-        uninitialized_transformers,
-    ):
-        """Test that an exception is raised if the total sample weights are 0."""
-
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["quantiles"] = {"a": [0.2, 0.9]}
-        args["capping_values"] = None
-        args["weights_column"] = "w"
-
-        df = pd.DataFrame(
-            {
-                "a": [1, 2, 3],
-                "w": [0, 0, 0],
-            },
-        )
-
-        transformer = uninitialized_transformers[self.transformer_name](**args)
-        with pytest.raises(
-            ValueError,
-            match=f"{self.transformer_name}: total sample weights are not greater than 0",
-        ):
-            transformer.fit(df)
-
     @pytest.mark.parametrize(
         ("values", "sample_weight", "quantiles", "expected_quantiles"),
         # quantiles use linear interpolation, which is manually replicated here where needed

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -14,6 +14,46 @@ from tests.base_tests import (
 )
 
 
+class GenericImputerFitTestsWeight:
+    def test_fit_returns_self_weighted(
+        self,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test fit returns self?."""
+        df = d.create_df_9()
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weight"] = "c"
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        x_fitted = transformer.fit(df)
+
+        assert (
+            x_fitted is transformer
+        ), f"Returned value from {self.transformer_name}.fit not as expected."
+
+    def test_fit_not_changing_data_weighted(
+        self,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test fit does not change X - when weights are used."""
+        df = d.create_df_9()
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weight"] = "c"
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        transformer.fit(df)
+        ta.equality.assert_equal_dispatch(
+            expected=d.create_df_9(),
+            actual=df,
+            msg=f"X changed during fit for {self.transformer_name}",
+        )
+
+
 class GenericImputerTransformTests:
     def test_not_fitted_error_raised(self, initialized_transformers):
         if initialized_transformers[self.transformer_name].FITS:
@@ -148,6 +188,74 @@ class GenericImputerTransformTests:
             expected=expected,
             actual=df_transformed,
             msg=f"Error from {self.transformer_name} transform col b, c",
+        )
+
+
+class GenericImputerTransformTestsWeight:
+    def expected_df_weights():
+        """Expected output for test_nulls_imputed_correctly_weights."""
+        df = d.create_df_9()
+
+        for col in ["a"]:
+            df.loc[df[col].isna(), col] = 4
+
+        return df
+
+    @pytest.mark.parametrize(
+        ("df", "expected"),
+        ta.pandas.row_by_row_params(d.create_df_9(), expected_df_weights())
+        + ta.pandas.index_preserved_params(d.create_df_9(), expected_df_weights()),
+    )
+    def test_nulls_imputed_correctly_weights(
+        self,
+        df,
+        expected,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test missing values are filled with the correct values - and unrelated columns are not changed
+        (when weight is used).
+        """
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["weight"] = "c"
+
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        # set the impute values dict directly rather than fitting x on df so test works with helpers
+        transformer.impute_values_ = {"a": 4}
+
+        df_transformed = transformer.transform(df)
+
+        ta.equality.assert_equal_dispatch(
+            expected=expected,
+            actual=df_transformed,
+            msg=f"Check nulls filled correctly in transform for {self.transformer_name}",
+        )
+
+    def test_learnt_values_not_modified_weights(
+        self,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test that the impute_values_ from fit are not changed in transform - when using weights."""
+        df = d.create_df_9()
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["columns"] = ["a", "b"]
+        args["weight"] = "c"
+
+        transformer1 = uninitialized_transformers[self.transformer_name](**args)
+
+        transformer1.fit(df)
+
+        transformer2 = uninitialized_transformers[self.transformer_name](**args)
+
+        transformer2.fit_transform(df)
+
+        ta.equality.assert_equal_dispatch(
+            expected=transformer1.impute_values_,
+            actual=transformer2.impute_values_,
+            msg=f"Impute values changed in transform for {self.transformer_name}",
         )
 
 

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -14,46 +14,6 @@ from tests.base_tests import (
 )
 
 
-class GenericImputerFitTestsWeight:
-    def test_fit_returns_self_weighted(
-        self,
-        minimal_attribute_dict,
-        uninitialized_transformers,
-    ):
-        """Test fit returns self?."""
-        df = d.create_df_9()
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = "c"
-
-        transformer = uninitialized_transformers[self.transformer_name](**args)
-
-        x_fitted = transformer.fit(df)
-
-        assert (
-            x_fitted is transformer
-        ), f"Returned value from {self.transformer_name}.fit not as expected."
-
-    def test_fit_not_changing_data_weighted(
-        self,
-        minimal_attribute_dict,
-        uninitialized_transformers,
-    ):
-        """Test fit does not change X - when weights are used."""
-        df = d.create_df_9()
-
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = "c"
-
-        transformer = uninitialized_transformers[self.transformer_name](**args)
-
-        transformer.fit(df)
-        ta.equality.assert_equal_dispatch(
-            expected=d.create_df_9(),
-            actual=df,
-            msg=f"X changed during fit for {self.transformer_name}",
-        )
-
-
 class GenericImputerTransformTests:
     def test_not_fitted_error_raised(self, initialized_transformers):
         if initialized_transformers[self.transformer_name].FITS:

--- a/tests/imputers/test_BaseImputer.py
+++ b/tests/imputers/test_BaseImputer.py
@@ -23,7 +23,7 @@ class GenericImputerFitTestsWeight:
         """Test fit returns self?."""
         df = d.create_df_9()
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weight"] = "c"
+        args["weights_column"] = "c"
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
 
@@ -42,7 +42,7 @@ class GenericImputerFitTestsWeight:
         df = d.create_df_9()
 
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weight"] = "c"
+        args["weights_column"] = "c"
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
 
@@ -217,7 +217,7 @@ class GenericImputerTransformTestsWeight:
         (when weight is used).
         """
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weight"] = "c"
+        args["weights_column"] = "c"
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
 
@@ -242,7 +242,7 @@ class GenericImputerTransformTestsWeight:
 
         args = minimal_attribute_dict[self.transformer_name].copy()
         args["columns"] = ["a", "b"]
-        args["weight"] = "c"
+        args["weights_column"] = "c"
 
         transformer1 = uninitialized_transformers[self.transformer_name](**args)
 

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -26,14 +26,14 @@ class TestInit:
         ):
             MeanImputer(columns=None, verbose=True)
 
-    @pytest.mark.parametrize("weight", (0, ["a"], {"a": 10}))
-    def test_weight_arg_errors(self, weight):
+    @pytest.mark.parametrize("weights_column", (0, ["a"], {"a": 10}))
+    def test_weight_arg_errors(self, weights_column):
         """Test that appropriate errors are throw for bad weight arg."""
         with pytest.raises(
             TypeError,
-            match="weight should be str or None",
+            match="weights_column should be str or None",
         ):
-            MeanImputer(columns=["s"], weight=weight)
+            MeanImputer(columns=["s"], weights_column=weights_column)
 
 
 class TestFit:
@@ -59,7 +59,7 @@ class TestFit:
         """Test that fit calls WeightColumnMixin.check_weights_column - when weights are used."""
         df = d.create_df_9()
 
-        x = MeanImputer(columns=["a", "b"], weight="c")
+        x = MeanImputer(columns=["a", "b"], weights_column="c")
 
         expected_call_args = {0: {"args": (d.create_df_9(), "c"), "kwargs": {}}}
 
@@ -95,7 +95,7 @@ class TestFit:
         """Test that the impute values learnt during fit are expected - when weights are used."""
         df = d.create_df_9()
 
-        x = MeanImputer(columns=["a", "b"], weight="c")
+        x = MeanImputer(columns=["a", "b"], weights_column="c")
 
         x.fit(df)
 
@@ -124,7 +124,7 @@ class TestFit:
         """Test fit returns self - when weight is used."""
         df = d.create_df_9()
 
-        x = MeanImputer(columns="a", weight="c")
+        x = MeanImputer(columns="a", weights_column="c")
 
         x_fitted = x.fit(df)
 
@@ -148,7 +148,7 @@ class TestFit:
         """Test fit does not change X - when weights are used."""
         df = d.create_df_9()
 
-        x = MeanImputer(columns="a", weight="c")
+        x = MeanImputer(columns="a", weights_column="c")
 
         x.fit(df)
 
@@ -282,7 +282,7 @@ class TestTransform:
     )
     def test_nulls_imputed_correctly_3(self, df, expected):
         """Test missing values are filled with the correct values - and unrelated columns are not changed."""
-        x = MeanImputer(columns=["a", "b"], weight="c")
+        x = MeanImputer(columns=["a", "b"], weights_column="c")
 
         # set the impute values dict directly rather than fitting x on df so test works with decorators
         x.impute_values_ = {"a": 59 / 15, "b": 42 / 18}
@@ -317,11 +317,11 @@ class TestTransform:
         """Test that the impute_values_ from fit are not changed in transform - when using weights."""
         df = d.create_df_9()
 
-        x = MeanImputer(columns=["a", "b"], weight="c")
+        x = MeanImputer(columns=["a", "b"], weights_column="c")
 
         x.fit(df)
 
-        x2 = MeanImputer(columns=["a", "b"], weight="c")
+        x2 = MeanImputer(columns=["a", "b"], weights_column="c")
 
         x2.fit_transform(df)
 

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -61,7 +61,7 @@ class TestFit:
 
         x = MeanImputer(columns=["a", "b"], weights_column="c")
 
-        expected_call_args = {0: {"args": (d.create_df_9(), "c"), "kwargs": {}}}
+        expected_call_args = {0: {"args": (x, d.create_df_9(), "c"), "kwargs": {}}}
 
         with ta.functions.assert_function_call(
             mocker,

--- a/tests/imputers/test_MeanImputer.py
+++ b/tests/imputers/test_MeanImputer.py
@@ -5,6 +5,7 @@ import test_aide as ta
 
 import tests.test_data as d
 import tubular
+import tubular.mixins
 from tubular.imputers import MeanImputer
 
 
@@ -55,7 +56,7 @@ class TestFit:
             x.fit(df)
 
     def test_check_weights_column_called(self, mocker):
-        """Test that fit calls BaseTransformer.check_weights_column - when weights are used."""
+        """Test that fit calls WeightColumnMixin.check_weights_column - when weights are used."""
         df = d.create_df_9()
 
         x = MeanImputer(columns=["a", "b"], weight="c")
@@ -64,7 +65,7 @@ class TestFit:
 
         with ta.functions.assert_function_call(
             mocker,
-            tubular.base.BaseTransformer,
+            tubular.mixins.WeightColumnMixin,
             "check_weights_column",
             expected_call_args,
         ):

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
 import test_aide as ta
 
 import tests.test_data as d
@@ -9,37 +8,25 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    WeightColumnInitTests,
 )
-from tests.imputers.test_BaseImputer import GenericImputerTransformTests
+from tests.imputers.test_BaseImputer import (
+    GenericImputerFitTestsWeight,
+    GenericImputerTransformTests,
+    GenericImputerTransformTestsWeight,
+)
 from tubular.imputers import MedianImputer
 
 
-class TestInit(ColumnStrListInitTests):
+class TestInit(ColumnStrListInitTests, WeightColumnInitTests):
     """Generic tests for transformer.init()."""
 
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MedianImputer"
 
-    @pytest.mark.parametrize("weight", (0, ["a"], {"a": 10}))
-    def test_weight_arg_errors(
-        self,
-        uninitialized_transformers,
-        minimal_attribute_dict,
-        weight,
-    ):
-        """Test that appropriate errors are throw for bad weight arg."""
-        args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weight"] = weight
 
-        with pytest.raises(
-            TypeError,
-            match="weight should be str or None",
-        ):
-            uninitialized_transformers[self.transformer_name](**args)
-
-
-class TestFit(GenericFitTests):
+class TestFit(GenericFitTests, GenericImputerFitTestsWeight):
     """Generic tests for transformer.fit()"""
 
     @classmethod
@@ -91,16 +78,6 @@ class TestFit(GenericFitTests):
             msg="impute_values_ attribute",
         )
 
-    def test_fit_returns_self_weighted(self):
-        """Test fit returns self?."""
-        df = d.create_df_9()
-
-        x = MedianImputer(columns="a", weight="c")
-
-        x_fitted = x.fit(df)
-
-        assert x_fitted is x, "Returned value from MedianImputer.fit not as expected."
-
     def test_fit_not_changing_data(self):
         """Test fit does not change X."""
         df = d.create_df_1()
@@ -115,76 +92,17 @@ class TestFit(GenericFitTests):
             msg="Check X not changing during fit",
         )
 
-    def test_fit_not_changing_data_weighted(self):
-        """Test fit does not change X."""
-        df = d.create_df_9()
 
-        x = MedianImputer(columns="a", weight="c")
-
-        x.fit(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=d.create_df_9(),
-            actual=df,
-            msg="Check X not changing during fit",
-        )
-
-
-class TestTransform(GenericImputerTransformTests, GenericTransformTests):
+class TestTransform(
+    GenericImputerTransformTests,
+    GenericImputerTransformTestsWeight,
+    GenericTransformTests,
+):
     """Tests for transformer.transform."""
 
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "MedianImputer"
-
-    def expected_df_weights():
-        """Expected output for test_nulls_imputed_correctly_weights."""
-        df = d.create_df_9()
-
-        for col in ["a"]:
-            df.loc[df[col].isna(), col] = 4
-
-        return df
-
-    @pytest.mark.parametrize(
-        ("df", "expected"),
-        ta.pandas.row_by_row_params(d.create_df_9(), expected_df_weights())
-        + ta.pandas.index_preserved_params(d.create_df_9(), expected_df_weights()),
-    )
-    def test_nulls_imputed_correctly_weights(self, df, expected):
-        """Test missing values are filled with the correct values - and unrelated columns are not changed
-        (when weight is used).
-        """
-        x = MedianImputer(columns=["a"], weight="c")
-
-        # set the impute values dict directly rather than fitting x on df so test works with helpers
-        x.impute_values_ = {"a": 4}
-
-        df_transformed = x.transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=expected,
-            actual=df_transformed,
-            msg="Check nulls filled correctly in transform",
-        )
-
-    def test_learnt_values_not_modified_weights(self):
-        """Test that the impute_values_ from fit are not changed in transform - when using weights."""
-        df = d.create_df_9()
-
-        x = MedianImputer(columns=["a", "b"], weight="c")
-
-        x.fit(df)
-
-        x2 = MedianImputer(columns=["a", "b"], weight="c")
-
-        x2.fit_transform(df)
-
-        ta.equality.assert_equal_dispatch(
-            expected=x.impute_values_,
-            actual=x2.impute_values_,
-            msg="Impute values not changed in transform",
-        )
 
 
 class TestOtherBaseBehaviour(OtherBaseBehaviourTests):

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -8,10 +8,10 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    WeightColumnFitTests,
     WeightColumnInitTests,
 )
 from tests.imputers.test_BaseImputer import (
-    GenericImputerFitTestsWeight,
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
 )
@@ -26,7 +26,7 @@ class TestInit(ColumnStrListInitTests, WeightColumnInitTests):
         cls.transformer_name = "MedianImputer"
 
 
-class TestFit(GenericFitTests, GenericImputerFitTestsWeight):
+class TestFit(WeightColumnFitTests, GenericFitTests):
     """Generic tests for transformer.fit()"""
 
     @classmethod

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -68,9 +68,7 @@ class TestFit(WeightColumnFitTests, GenericFitTests):
             },
         )
 
-
-        x = MedianImputer(columns=["a"], weights_column="c")
-
+        x = MedianImputer(columns=["a", "d"], weights_column="c")
 
         x.fit(df)
 

--- a/tests/imputers/test_MedianImputer.py
+++ b/tests/imputers/test_MedianImputer.py
@@ -64,7 +64,7 @@ class TestFit(GenericFitTests, GenericImputerFitTestsWeight):
             },
         )
 
-        x = MedianImputer(columns=["a"], weight="c")
+        x = MedianImputer(columns=["a"], weights_column="c")
 
         x.fit(df)
 

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -82,7 +82,7 @@ class TestFit(GenericFitTests, GenericImputerFitTestsWeight):
         """Test that the impute values learnt during fit are expected when df is weighted."""
         df = d.create_weighted_imputers_test_df()
 
-        x = ModeImputer(columns=["a", "b", "c", "d"], weight="weight")
+        x = ModeImputer(columns=["a", "b", "c", "d"], weights_column="weights_column")
 
         x.fit(df)
 

--- a/tests/imputers/test_ModeImputer.py
+++ b/tests/imputers/test_ModeImputer.py
@@ -9,10 +9,10 @@ from tests.base_tests import (
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
+    WeightColumnFitTests,
     WeightColumnInitTests,
 )
 from tests.imputers.test_BaseImputer import (
-    GenericImputerFitTestsWeight,
     GenericImputerTransformTests,
     GenericImputerTransformTestsWeight,
 )
@@ -27,7 +27,7 @@ class TestInit(ColumnStrListInitTests, WeightColumnInitTests):
         cls.transformer_name = "ModeImputer"
 
 
-class TestFit(GenericFitTests, GenericImputerFitTestsWeight):
+class TestFit(WeightColumnFitTests, GenericFitTests):
     """Generic tests for transformer.fit()"""
 
     @classmethod

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -101,7 +101,7 @@ class TestFit:
 
         with pytest.raises(
             ValueError,
-            match="GroupRareLevelsTransformer: weight aaaa not in X",
+            match=r"weight col \(aaaa\) is not present in columns of data",
         ):
             x.fit(df)
 
@@ -238,7 +238,7 @@ class TestTransform:
         """Expected output for test_expected_output_weight."""
         df = pd.DataFrame(
             {
-                "a": [2, 2, 2, 2, np.nan, 2, 2, 2, 3, 3],
+                "a": [2, 2, 2, 2, 0, 2, 2, 2, 3, 3],
                 "b": ["a", "a", "a", "d", "e", "f", "g", np.nan, np.nan, np.nan],
                 "c": ["a", "b", "c", "d", "f", "f", "f", "g", "g", np.nan],
             },

--- a/tests/nominal/test_GroupRareLevelsTransformer.py
+++ b/tests/nominal/test_GroupRareLevelsTransformer.py
@@ -52,10 +52,10 @@ class TestInit:
     def test_weight_not_str_error(self):
         """Test that an exception is raised if weight is not a str, if supplied."""
         with pytest.raises(
-            ValueError,
-            match="GroupRareLevelsTransformer: weight should be a single column",
+            TypeError,
+            match="weights_column should be str or None",
         ):
-            GroupRareLevelsTransformer(columns="a", weight=2)
+            GroupRareLevelsTransformer(columns="a", weights_column=2)
 
     def test_record_rare_levels_not_bool_error(self):
         """Test that an exception is raised if record_rare_levels is not a bool."""
@@ -97,7 +97,7 @@ class TestFit:
         """Test that an exception is raised if weight is not in X."""
         df = d.create_df_5()
 
-        x = GroupRareLevelsTransformer(columns=["b", "c"], weight="aaaa")
+        x = GroupRareLevelsTransformer(columns=["b", "c"], weights_column="aaaa")
 
         with pytest.raises(
             ValueError,
@@ -151,7 +151,11 @@ class TestFit:
         """Test that the impute values learnt during fit, using a weight, are expected."""
         df = d.create_df_6()
 
-        x = GroupRareLevelsTransformer(columns=["b"], cut_off_percent=0.3, weight="a")
+        x = GroupRareLevelsTransformer(
+            columns=["b"],
+            cut_off_percent=0.3,
+            weights_column="a",
+        )
 
         x.fit(df)
 
@@ -165,7 +169,11 @@ class TestFit:
         """Test that the impute values learnt during fit, using a weight, are expected."""
         df = d.create_df_6()
 
-        x = GroupRareLevelsTransformer(columns=["c"], cut_off_percent=0.2, weight="a")
+        x = GroupRareLevelsTransformer(
+            columns=["c"],
+            cut_off_percent=0.2,
+            weights_column="a",
+        )
 
         x.fit(df)
 
@@ -383,7 +391,11 @@ class TestTransform:
     )
     def test_expected_output_weight(self, df, expected):
         """Test that the output is expected from transform, when weights are used."""
-        x = GroupRareLevelsTransformer(columns=["b"], cut_off_percent=0.3, weight="a")
+        x = GroupRareLevelsTransformer(
+            columns=["b"],
+            cut_off_percent=0.3,
+            weights_column="a",
+        )
 
         # set the mappging dict directly rather than fitting x on df so test works with decorators
         x.non_rare_levels = {"b": ["a", np.nan]}

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -109,7 +109,7 @@ class TestInit:
         """Test that an exception is raised if weights_column is not a str."""
         with pytest.raises(
             TypeError,
-            match="MeanResponseTransformer: weights_column should be a str",
+            match="weights_column should be str or None",
         ):
             MeanResponseTransformer(weights_column=1)
 

--- a/tests/nominal/test_MeanResponseTransformer.py
+++ b/tests/nominal/test_MeanResponseTransformer.py
@@ -770,7 +770,7 @@ class TestFitBinaryResponse:
 
         with pytest.raises(
             ValueError,
-            match="MeanResponseTransformer: weights column z not in X",
+            match=r"weight col \(z\) is not present in columns of data",
         ):
             x._fit_binary_response(df, df["a"], x.columns)
 

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -14,7 +14,7 @@ class TestInit:
         """Test that an exception is raised if weights_column is not a str."""
         with pytest.raises(
             TypeError,
-            match="OrdinalEncoderTransformer: weights_column should be a str",
+            match="weights_column",
         ):
             OrdinalEncoderTransformer(weights_column=1)
 

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -14,7 +14,7 @@ class TestInit:
         """Test that an exception is raised if weights_column is not a str."""
         with pytest.raises(
             TypeError,
-            match="weights_column",
+            match="weights_column should be str or None",
         ):
             OrdinalEncoderTransformer(weights_column=1)
 

--- a/tests/nominal/test_OrdinalEncoderTransformer.py
+++ b/tests/nominal/test_OrdinalEncoderTransformer.py
@@ -134,7 +134,7 @@ class TestFit:
 
         with pytest.raises(
             ValueError,
-            match="OrdinalEncoderTransformer: weights column z not in X",
+            match=r"weight col \(z\) is not present in columns of data",
         ):
             x.fit(df, df["a"])
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -239,7 +239,7 @@ def create_weighted_imputers_test_df():
             "c": ["a", "a", np.nan, np.nan, np.nan, "f"],
             "d": [1.0, 5.0, 3.0, np.nan, np.nan, 1.0],
             "response": [0, 1, 0, 1, 1, 1],
-            "weight": [0.1, 0.1, 0.8, 0.5, 0.9, 0.8],
+            "weights_column": [0.1, 0.1, 0.8, 0.5, 0.9, 0.8],
         },
     )
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -106,7 +106,7 @@ def create_df_6():
     """Nulls in different positions to check summing weights by col with nulls."""
     df = pd.DataFrame(
         {
-            "a": [2, 2, 2, 2, np.nan, 2, 2, 2, 3, 3],
+            "a": [2, 2, 2, 2, 0, 2, 2, 2, 3, 3],
             "b": ["a", "a", "a", "d", "e", "f", "g", np.nan, np.nan, np.nan],
             "c": ["a", "b", "c", "d", "f", "f", "f", "g", "g", np.nan],
         },

--- a/tubular/base.py
+++ b/tubular/base.py
@@ -239,39 +239,6 @@ class BaseTransformer(TransformerMixin, BaseEstimator):
             if c not in X.columns.to_numpy():
                 raise ValueError(f"{self.classname()}: variable " + c + " is not in X")
 
-    @staticmethod
-    def check_weights_column(X: pd.DataFrame, weights_column: str) -> None:
-        """Helper method for validating weights column in dataframe.
-
-        Args:
-        ----
-            X (pd.DataFrame): df containing weight column
-            weights_column (str): name of weight column
-
-        """
-        if weights_column is not None:
-            # check if given weight is in columns
-            if weights_column not in X.columns:
-                msg = f"weight col ({weights_column}) is not present in columns of data"
-                raise ValueError(msg)
-
-            # check weight is numeric
-
-            if not pd.api.types.is_numeric_dtype(X[weights_column]):
-                msg = "weight column must be numeric."
-                raise ValueError(msg)
-
-            # check weight is positive
-
-            if (X[weights_column] < 0).sum() != 0:
-                msg = "weight column must be positive"
-                raise ValueError(msg)
-
-            # check weight non-null
-            if X[weights_column].isna().sum() != 0:
-                msg = "weight column must be non-null"
-                raise ValueError(msg)
-
 
 class DataFrameMethodTransformer(BaseTransformer):
     """Tranformer that applies a pandas.DataFrame method.

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -9,9 +9,10 @@ import numpy as np
 import pandas as pd
 
 from tubular.base import BaseTransformer
+from tubular.mixins import WeightColumnMixin
 
 
-class BaseCappingTransformer(BaseTransformer):
+class BaseCappingTransformer(BaseTransformer, WeightColumnMixin):
     def __init__(
         self,
         capping_values: dict[str, list[int | float | None]] | None = None,
@@ -170,6 +171,9 @@ class BaseCappingTransformer(BaseTransformer):
             Required for pipeline.
 
         """
+        if self.weights_column:
+            WeightColumnMixin.check_weights_column(X, self.weights_column)
+
         super().fit(X, y)
 
         self.quantile_capping_values = {}

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -98,7 +98,7 @@ class BaseCappingTransformer(BaseTransformer, WeightColumnMixin):
             super().__init__(columns=list(quantiles.keys()), **kwargs)
 
         self.quantiles = quantiles
-        self.weights_column = weights_column
+        WeightColumnMixin.check_and_set_weight(self, weights_column)
 
     def check_capping_values_dict(
         self,
@@ -492,10 +492,6 @@ class CappingTransformer(BaseCappingTransformer):
         if capping_values:
             self._replacement_values = copy.deepcopy(self.capping_values)
 
-        if weights_column is not None and not isinstance(weights_column, str):
-            msg = "weights_column should be str or None"
-            raise TypeError(msg)
-
     def fit(self, X: pd.DataFrame, y: None = None) -> CappingTransformer:
         """Learn capping values from input data X.
 
@@ -592,10 +588,6 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
             self._replacement_values = OutOfRangeNullTransformer.set_replacement_values(
                 self.capping_values,
             )
-
-        if weights_column is not None and not isinstance(weights_column, str):
-            msg = "weights_column should be str or None"
-            raise TypeError(msg)
 
     @staticmethod
     def set_replacement_values(capping_values: dict[str, list[float]]) -> None:

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -172,7 +172,7 @@ class BaseCappingTransformer(BaseTransformer, WeightColumnMixin):
 
         """
         if self.weights_column:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
         super().fit(X, y)
 

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -492,6 +492,10 @@ class CappingTransformer(BaseCappingTransformer):
         if capping_values:
             self._replacement_values = copy.deepcopy(self.capping_values)
 
+        if weights_column is not None and not isinstance(weights_column, str):
+            msg = "weights_column should be str or None"
+            raise TypeError(msg)
+
     def fit(self, X: pd.DataFrame, y: None = None) -> CappingTransformer:
         """Learn capping values from input data X.
 
@@ -588,6 +592,10 @@ class OutOfRangeNullTransformer(BaseCappingTransformer):
             self._replacement_values = OutOfRangeNullTransformer.set_replacement_values(
                 self.capping_values,
             )
+
+        if weights_column is not None and not isinstance(weights_column, str):
+            msg = "weights_column should be str or None"
+            raise TypeError(msg)
 
     @staticmethod
     def set_replacement_values(capping_values: dict[str, list[float]]) -> None:

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -181,7 +181,7 @@ class MedianImputer(BaseImputer, WeightColumnMixin):
         self.impute_values_ = {}
 
         if self.weights_column is not None:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
             for c in self.columns:
                 # filter out null rows so their weight doesn't influence calc
@@ -263,7 +263,7 @@ class MeanImputer(BaseImputer, WeightColumnMixin):
         self.impute_values_ = {}
 
         if self.weights_column is not None:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
             for c in self.columns:
                 # filter out null rows so they don't count towards total weight
@@ -355,7 +355,7 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
                     self.impute_values_[c] = mode_value[0]
 
         else:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
             for c in self.columns:
                 grouped = X.groupby(c)[self.weights_column].sum()

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -323,8 +323,8 @@ class ModeImputer(BaseImputer, WeightColumnMixin):
         super().__init__(columns=columns, **kwargs)
 
         if weight is not None and not isinstance(weight, str):
-            msg = "ModeImputer: weight should be a string or None"
-            raise ValueError(msg)
+            msg = "weight should be str or None"
+            raise TypeError(msg)
 
         self.weight = weight
 

--- a/tubular/imputers.py
+++ b/tubular/imputers.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 from tubular.base import BaseTransformer
+from tubular.mixins import WeightColumnMixin
 
 
 class BaseImputer(BaseTransformer):
@@ -128,7 +129,7 @@ class ArbitraryImputer(BaseImputer):
         return X_transformed
 
 
-class MedianImputer(BaseImputer):
+class MedianImputer(BaseImputer, WeightColumnMixin):
     """Transformer to impute missing values with the median of the supplied columns.
 
     Parameters
@@ -184,7 +185,7 @@ class MedianImputer(BaseImputer):
         self.impute_values_ = {}
 
         if self.weight is not None:
-            super().check_weights_column(X, self.weight)
+            WeightColumnMixin.check_weights_column(X, self.weight)
 
             for c in self.columns:
                 # filter out null rows so their weight doesn't influence calc
@@ -211,7 +212,7 @@ class MedianImputer(BaseImputer):
         return self
 
 
-class MeanImputer(BaseImputer):
+class MeanImputer(BaseImputer, WeightColumnMixin):
     """Transformer to impute missing values with the mean of the supplied columns.
 
     Parameters
@@ -265,7 +266,7 @@ class MeanImputer(BaseImputer):
         self.impute_values_ = {}
 
         if self.weight is not None:
-            super().check_weights_column(X, self.weight)
+            WeightColumnMixin.check_weights_column(X, self.weight)
 
             for c in self.columns:
                 # filter out null rows so they don't count towards total weight
@@ -287,7 +288,7 @@ class MeanImputer(BaseImputer):
         return self
 
 
-class ModeImputer(BaseImputer):
+class ModeImputer(BaseImputer, WeightColumnMixin):
     """Transformer to impute missing values with the mode of the supplied columns.
 
     If mode is NaN, a warning will be raised.
@@ -359,7 +360,7 @@ class ModeImputer(BaseImputer):
                     self.impute_values_[c] = mode_value[0]
 
         else:
-            super().check_weights_column(X, self.weight)
+            WeightColumnMixin.check_weights_column(X, self.weight)
 
             for c in self.columns:
                 grouped = X.groupby(c)[self.weight].sum()

--- a/tubular/mixins.py
+++ b/tubular/mixins.py
@@ -38,3 +38,9 @@ class WeightColumnMixin:
         if np.isinf(X[weights_column]).any():
             msg = "weight column must not contain infinite values."
             raise ValueError(msg)
+
+    def check_and_set_weight(self, weights_column: str) -> None:
+        if weights_column is not None and not isinstance(weights_column, str):
+            msg = "weights_column should be str or None"
+            raise TypeError(msg)
+        self.weights_column = weights_column

--- a/tubular/mixins.py
+++ b/tubular/mixins.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+
+
+class WeightColumnMixin:
+    def check_weights_column(X: pd.DataFrame, weights_column: str) -> None:
+        """Helper method for validating weights column in dataframe.
+
+        Args:
+        ----
+            X (pd.DataFrame): df containing weight column
+            weights_column (str): name of weight column
+
+        """
+        # check if given weight is in columns
+        if weights_column not in X.columns:
+            msg = f"weight col ({weights_column}) is not present in columns of data"
+            raise ValueError(msg)
+
+        # check weight is numeric
+
+        if not pd.api.types.is_numeric_dtype(X[weights_column]):
+            msg = "weight column must be numeric."
+            raise ValueError(msg)
+
+        # check weight is positive
+
+        if (X[weights_column] < 0).sum() != 0:
+            msg = "weight column must be positive"
+            raise ValueError(msg)
+
+        # check weight non-null
+        if X[weights_column].isna().sum() != 0:
+            msg = "weight column must be non-null"
+            raise ValueError(msg)
+
+        # check weight not inf
+        if np.isinf(X[weights_column]).any():
+            msg = "weight column must not contain infinite values."
+            raise ValueError(msg)

--- a/tubular/mixins.py
+++ b/tubular/mixins.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 
 class WeightColumnMixin:
-    def check_weights_column(X: pd.DataFrame, weights_column: str) -> None:
+    def check_weights_column(self, X: pd.DataFrame, weights_column: str) -> None:
         """Helper method for validating weights column in dataframe.
 
         Args:
@@ -14,32 +14,51 @@ class WeightColumnMixin:
         """
         # check if given weight is in columns
         if weights_column not in X.columns:
-            msg = f"weight col ({weights_column}) is not present in columns of data"
+            msg = f"{self.classname()}: weight col ({weights_column}) is not present in columns of data"
             raise ValueError(msg)
 
         # check weight is numeric
 
         if not pd.api.types.is_numeric_dtype(X[weights_column]):
-            msg = "weight column must be numeric."
+            msg = f"{self.classname()}: weight column must be numeric."
             raise ValueError(msg)
 
         # check weight is positive
 
         if (X[weights_column] < 0).sum() != 0:
-            msg = "weight column must be positive"
+            msg = f"{self.classname()}: weight column must be positive"
             raise ValueError(msg)
 
         # check weight non-null
         if X[weights_column].isna().sum() != 0:
-            msg = "weight column must be non-null"
+            msg = f"{self.classname()}: weight column must be non-null"
             raise ValueError(msg)
 
         # check weight not inf
         if np.isinf(X[weights_column]).any():
-            msg = "weight column must not contain infinite values."
+            msg = f"{self.classname()}: weight column must not contain infinite values."
+            raise ValueError(msg)
+
+        if X[weights_column].sum() <= 0:
+            msg = f"{self.classname()}: total sample weights are not greater than 0"
             raise ValueError(msg)
 
     def check_and_set_weight(self, weights_column: str) -> None:
+        """Helper method that validates and assigns the specified column name to be used as the weights_column attribute.
+        This function ensures that the `weights_column` parameter is either a string representing
+        the column name or None. If `weights_column` is not of type str and is not None, it raises
+        a TypeError.
+
+        Parameters:
+            weights_column (str or None): The name of the column to be used as weights. If None, no weights are used.
+
+        Raises:
+            TypeError: If `weights_column` is neither a string nor None.
+
+        Returns:
+            None
+        """
+
         if weights_column is not None and not isinstance(weights_column, str):
             msg = "weights_column should be str or None"
             raise TypeError(msg)

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -336,7 +336,7 @@ class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
         super().fit(X, y)
 
         if self.weights_column is not None:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
         for c in self.columns:
             if (X[c].dtype.name != "category") and (
@@ -669,7 +669,7 @@ class MeanResponseTransformer(BaseNominalTransformer, WeightColumnMixin):
             being encoded against in this call of _fit_binary_response.
         """
         if self.weights_column is not None:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
         response_null_count = y.isna().sum()
 
@@ -959,7 +959,7 @@ class OrdinalEncoderTransformer(
         self.mappings = {}
 
         if self.weights_column is not None:
-            WeightColumnMixin.check_weights_column(X, self.weights_column)
+            WeightColumnMixin.check_weights_column(self, X, self.weights_column)
 
         response_null_count = y.isna().sum()
 

--- a/tubular/nominal.py
+++ b/tubular/nominal.py
@@ -200,9 +200,8 @@ class NominalToIntegerTransformer(BaseNominalTransformer, BaseMappingTransformMi
         return X
 
 
-
 class GroupRareLevelsTransformer(BaseTransformer, WeightColumnMixin):
-  
+
     """Transformer to group together rare levels of nominal variables into a new level,
     labelled 'rare' (by default).
 


### PR DESCRIPTION
The following work has been done as part of this PR:

1. WeightColumnMixin mixin class created in a new file mixins.py with check_weights_column method to replace check_weights_column method in base.py: Commit [4bff09e3](4bff09e3ee8e38ce9b549fe49bbc3c7738982737). Note that post implementing this check_weights_column check for weighted transformers, some tests for nominal transformers failed since the testing data was using null values in weight column, which logically shouldn't be allowed. This testing data has been updated to not contain null values in weight column.

2. Refactored testing of weighted transformers to move shared tests in generic testing classes: Commit [43827aad](43827aade09060284f76b8e6634d0efdbc4a6f86). As part of this, the following work was done:

    1. Created WeightColumnInitTests class with test to check that the weight is str or None. Consequently, test_weight_arg_errors and test_weight_value_type_error tests removed from test_MedianImputer.py and test_ModeImputer.py. Similar test in mean imputer not touched for now (test should be removed as part of mean imputer test overhaul ticket: https://github.com/lvgig/tubular/issues/208)
    2. Added test_weight_arg_errors to GenericCappingInitTests class of test_BaseCappingTransformer.py to check that the weight is str or None for CappingTransformer and OutOfRangeNullTransformer.
    3. Added generic weight testing classes GenericImputerFitTestsWeight and GenericImputerTransformTestsWeight to test_BaseImputer.py and removed duplicated fit and transform weight tests in test_MedianImputer.py and test_ModeImputer.py
