### PR TITLE
Created generic two column init tests and tidied test_EqualityChecker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,9 @@ Changed
 - Refactored MedianImputer tests in new format.
 - Replaced occurrences of pd.Dataframe.drop() with del statement to speed up tubular. Note that no additional unit testing has been done for copy=False as this release is scheduled to remove copy. 
 - Refactored BaseNominalTransformer tests in new format & moved its logic to the transform method.
+- Refactored ModeImputer tests in new format.
+- Added generic init tests to base tests for transformers that take two columns as an input.
+- Refactored EqualityChecker tests in new format.
 
 Removed
 ^^^^^^^

--- a/tests/base/test_DataFrameMethodTransformer.py
+++ b/tests/base/test_DataFrameMethodTransformer.py
@@ -85,7 +85,7 @@ class DataFrameMethodTransformerInitTests(ColumnStrListInitTests):
 
     @pytest.mark.parametrize("not_bool", [{"a": 1}, [1, 2], 1, "True", 1.5])
     def test_exception_raised_drop_original_not_bool(self, not_bool):
-        """Test an exception is raised if pd_method_name is not a string"""
+        """Test an exception is raised if drop_original is not a string"""
 
         with pytest.raises(
             TypeError,

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -73,7 +73,10 @@ class ColumnStrListInitTests(GenericInitTests):
         with pytest.raises(ValueError):
             uninitialized_transformers[self.transformer_name](**args)
 
-    @pytest.mark.parametrize("non_string", [1, True, {"a": 1}, [1, 2], None])
+    @pytest.mark.parametrize(
+        "non_string",
+        [1, True, {"a": 1}, [1, 2], None, np.inf, np.nan],
+    )
     def test_columns_list_element_error(
         self,
         non_string,
@@ -93,7 +96,10 @@ class ColumnStrListInitTests(GenericInitTests):
         ):
             uninitialized_transformers[self.transformer_name](**args)
 
-    @pytest.mark.parametrize("non_string_or_list", [1, True, {"a": 1}, None])
+    @pytest.mark.parametrize(
+        "non_string_or_list",
+        [1, True, {"a": 1}, None, np.inf, np.nan],
+    )
     def test_columns_non_string_or_list_error(
         self,
         non_string_or_list,
@@ -109,6 +115,76 @@ class ColumnStrListInitTests(GenericInitTests):
             TypeError,
             match=re.escape(
                 f"{self.transformer_name}: columns must be a string or list with the columns to be pre-processed (if specified)",
+            ),
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
+
+class TwoColumnListInitTests(ColumnStrListInitTests):
+    """
+    Tests for BaseTransformer.init() behaviour specific to when a transformer takes two columns as a list.
+    Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
+    """
+
+    @pytest.mark.parametrize("non_list", ["a", "b", "c"])
+    def test_columns_non_list_error(
+        self,
+        non_list,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test an error is raised if columns is not passed as a list."""
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["columns"] = non_list
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                f"{self.transformer_name}: columns should be list",
+            ),
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
+    @pytest.mark.parametrize("list_length", [["a", "a", "a"], ["a"]])
+    def test_list_length_error(
+        self,
+        list_length,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test an error is raised if list of any length other than 2 is passed"""
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["columns"] = list_length
+
+        with pytest.raises(
+            ValueError,
+            match=re.escape(
+                f"{self.transformer_name}: This transformer works with two columns only",
+            ),
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
+    @pytest.mark.parametrize(
+        "new_column_type",
+        [1, True, {"a": 1}, [1, 2], None, np.inf, np.nan],
+    )
+    def test_new_column_type_error(
+        self,
+        new_column_type,
+        minimal_attribute_dict,
+        uninitialized_transformers,
+    ):
+        """Test an error is raised if any type other than str passed to new_column_type"""
+
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["new_col_name"] = new_column_type
+
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                f"{self.transformer_name}: new_col_name should be str",
             ),
         ):
             uninitialized_transformers[self.transformer_name](**args)

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -133,7 +133,7 @@ class TwoColumnListInitTests(ColumnStrListInitTests):
         minimal_attribute_dict,
         uninitialized_transformers,
     ):
-        """Test an error is raised if columns is not passed as a list."""
+        """Test an error is raised if columns is not passed as a string not a list."""
 
         args = minimal_attribute_dict[self.transformer_name].copy()
         args["columns"] = non_list
@@ -170,13 +170,13 @@ class TwoColumnListInitTests(ColumnStrListInitTests):
         "new_column_type",
         [1, True, {"a": 1}, [1, 2], None, np.inf, np.nan],
     )
-    def test_new_column_type_error(
+    def test_new_column_name_type_error(
         self,
         new_column_type,
         minimal_attribute_dict,
         uninitialized_transformers,
     ):
-        """Test an error is raised if any type other than str passed to new_column_type"""
+        """Test an error is raised if any type other than str passed to new_column_name"""
 
         args = minimal_attribute_dict[self.transformer_name].copy()
         args["new_col_name"] = new_column_type

--- a/tests/comparison/test_EqualityChecker.py
+++ b/tests/comparison/test_EqualityChecker.py
@@ -1,113 +1,46 @@
+import re
+
 import pytest
 import test_aide as ta
 
 import tests.test_data as d
-import tubular
+from tests.base_tests import (
+    GenericTransformTests,
+    TwoColumnListInitTests,
+)
 from tubular.comparison import EqualityChecker
 
 
-@pytest.fixture(scope="module", autouse=True)
-def example_transformer():
-    return EqualityChecker(columns=["a", "b"], new_col_name="d")
+class TestInit(TwoColumnListInitTests):
+    """Generic tests for transformer.init()."""
 
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "EqualityChecker"
 
-class TestInit:
-    """Tests for the EqualityChecker.__init__ method."""
+    @pytest.mark.parametrize("not_bool", [{"a": 1}, [1, 2], 1, "True", 1.5])
+    def test_exception_raised_drop_original_not_bool(self, not_bool):
+        """Test an exception is raised if drop_original is not a string"""
 
-    def test_super_init_call(self, mocker):
-        """Test that BaseTransformer.init is called as expected."""
-        expected_call_args = {
-            0: {
-                "args": (),
-                "kwargs": {"columns": ["a", "b"], "verbose": False},
-            },
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
+        with pytest.raises(
+            TypeError,
+            match=re.escape(
+                "EqualityChecker: drop_original should be bool",
+            ),
         ):
             EqualityChecker(
-                columns=["a", "b"],
-                new_col_name="d",
-                verbose=False,
-            )
-
-    def test_value_new_col_name(self, example_transformer):
-        """Test that the value passed in the new column name arg is correct."""
-        assert (
-            example_transformer.new_col_name == "d"
-        ), "unexpected value set to new_col_name atttribute"
-
-    def test_value_drop_original(self, example_transformer):
-        """Test that the value passed in the drop_original arg is correct."""
-        assert (
-            not example_transformer.drop_original
-        ), "unexpected value set to drop_original atttribute"
-
-    def test_type_error_for_columns(self):
-        """
-        Checks that an error is raised if wrong data type for argument:columns.
-
-        This is distinct from the BaseTransformer columns in put check as equality checker will only work
-        with columns as a list, not a string.
-        """
-        with pytest.raises(
-            TypeError,
-            match="columns should be list",
-        ):
-            EqualityChecker(columns="a", new_col_name="d")
-
-    @pytest.mark.parametrize("test_input_col", [["b", "b", "b"], ["a"]])
-    def test_value_error_for_columns(self, test_input_col):
-        """Checks that a value error is raised where 2 cols are not supplied."""
-        with pytest.raises(
-            ValueError,
-            match="This transformer works with two columns only",
-        ):
-            EqualityChecker(columns=test_input_col, new_col_name="d")
-
-    @pytest.mark.parametrize("test_input_new_col", [123, ["a"], True])
-    def test_type_error_for_new_column_name(self, test_input_new_col):
-        """Checks that an error is raised if wrong data type for argument:new_col_name."""
-        with pytest.raises(
-            TypeError,
-            match="new_col_name should be str",
-        ):
-            EqualityChecker(columns=["a", "b"], new_col_name=test_input_new_col)
-
-    @pytest.mark.parametrize("test_input_drop_col", [123, ["a"], "asd"])
-    def test_type_error_for_drop_column(self, test_input_drop_col):
-        """Checks that an error is raised if wrong data type for argument:drop_original."""
-        with pytest.raises(
-            TypeError,
-            match="drop_original should be bool",
-        ):
-            EqualityChecker(
-                columns=["a", "b"],
-                new_col_name="col_name",
-                drop_original=test_input_drop_col,
+                new_col_name="a",
+                columns=["b", "c"],
+                drop_original=not_bool,
             )
 
 
-class TestTransform:
-    """Tests for the EqualityChecker.transform method."""
+class TestTransform(GenericTransformTests):
+    """Tests for transformer.transform."""
 
-    def test_super_transform_called(self, mocker, example_transformer):
-        """Test that BaseTransformer.transform called."""
-        df = d.create_df_7()
-
-        expected_call_args = {0: {"args": (d.create_df_7(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "transform",
-            expected_call_args,
-        ):
-            example_transformer.transform(df)
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "EqualityChecker"
 
     @pytest.mark.parametrize(
         "test_dataframe",

--- a/tests/comparison/test_EqualityChecker.py
+++ b/tests/comparison/test_EqualityChecker.py
@@ -5,7 +5,9 @@ import test_aide as ta
 
 import tests.test_data as d
 from tests.base_tests import (
+    GenericFitTests,
     GenericTransformTests,
+    OtherBaseBehaviourTests,
     TwoColumnListInitTests,
 )
 from tubular.comparison import EqualityChecker
@@ -33,6 +35,14 @@ class TestInit(TwoColumnListInitTests):
                 columns=["b", "c"],
                 drop_original=not_bool,
             )
+
+
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "EqualityChecker"
 
 
 class TestTransform(GenericTransformTests):
@@ -91,3 +101,15 @@ class TestTransform(GenericTransformTests):
             msg_tag="EqualityChecker transformer does not produce the expected output",
             print_actual_and_expected=True,
         )
+
+
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
+
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "EqualityChecker"


### PR DESCRIPTION
Looking to address two outstanding issues

[204, generic init class for two column transformers](https://github.com/lvgig/tubular/issues/204
)
[205, bring EqualityChecker test in line with new format](https://github.com/lvgig/tubular/issues/205)

Hopefully this new generic class can be used for many of the date transformers, which use two columns as an input. At this stage these transformers take two separate args which are combined into a list, rather than the EqualityChecker which takes a list with two objects. After speaking with @limlam96 agreed that updating the date transformers to take as single arg sits outside this ticket. 

**'test_columns_non_list_error' seems to fail if anything other than string passed to pytest.mark.parametrize due to EqualityChecker reference to BaseTransformer which only accepts str or list, might be missing something here.**
