### PR TITLE
refactored dates file to prepare for testing. Edited base classes to …

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,8 @@ Moved tests for these objects to new approach.
 - Added generic init tests to base tests for transformers that take two columns as an input.
 - Refactored EqualityChecker tests in new format.
 - Bugfix to MeanResponseTransformer to ignore unobserved categorical levels
+- Refactored dates.py to prepare for testing refactor. Edited BaseDateTransformer (and created BaseDateTwoColumnTransformer) to follow standard format, implementing validations at init/fit/transform. 
+To reduce complexity of file, made transformers more opinionated to insist on specific and consistent column dtypes. 
 
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -39,16 +39,14 @@ Changed
 - Refactored ArbitraryImputer and BaseImputer tests in new format.
 - Refactored MedianImputer tests in new format.
 - Replaced occurrences of pd.Dataframe.drop() with del statement to speed up tubular. Note that no additional unit testing has been done for copy=False as this release is scheduled to remove copy. 
-- Created BaseCrossColumnNumericTransformer class. Refactored CrossColumnAddTransformer and CrossColumnMultiplyTransformer to use this class. 
-Moved tests for these objects to new approach.
+- Created BaseCrossColumnNumericTransformer class. Refactored CrossColumnAddTransformer and CrossColumnMultiplyTransformer to use this class. Moved tests for these objects to new approach.
 - Created BaseCrossColumnMappingTransformer class and integrated into CrossColumnMappingTransformer tests  
 - Refactored BaseNominalTransformer tests in new format & moved its logic to the transform method.
 - Refactored ModeImputer tests in new format.
 - Added generic init tests to base tests for transformers that take two columns as an input.
 - Refactored EqualityChecker tests in new format.
 - Bugfix to MeanResponseTransformer to ignore unobserved categorical levels
-- Refactored dates.py to prepare for testing refactor. Edited BaseDateTransformer (and created BaseDateTwoColumnTransformer) to follow standard format, implementing validations at init/fit/transform. 
-To reduce complexity of file, made transformers more opinionated to insist on specific and consistent column dtypes. 
+- Refactored dates.py to prepare for testing refactor. Edited BaseDateTransformer (and created BaseDateTwoColumnTransformer) to follow standard format, implementing validations at init/fit/transform. To reduce complexity of file, made transformers more opinionated to insist on specific and consistent column dtypes.  `#246 <https://github.com/lvgig/tubular/pull/246>`_
 - Added test_BaseTwoColumnTransformer base class for columns that require a list of two columns for input
 - Added BaseDropOriginalMixin to mixin transformers to handle validation and method of dropping original features, also added appropriate test classes.
 
@@ -58,7 +56,7 @@ Removed
 - Functionality for BaseTransformer (and thus all transformers) to take `None` as an option for columns. This behaviour was inconsistently implemented across transformers. Rather than extending to all we decided to remove 
 this functionality. This required updating a lot of test files.
 - The `columns_set_or_check()` method from BaseTransformer. With the above change it was no longer necessary. Subsequent updates to nominal transformers and their tests were required.
-- Set pd copy_on_write to True (will become default in pandas 3.0) which allowed the functionality of the copy method of the transformers to be dropped `#197 <https://github.com/lvgig/tubular/pull/197>`
+- Set pd copy_on_write to True (will become default in pandas 3.0) which allowed the functionality of the copy method of the transformers to be dropped `#197 <https://github.com/lvgig/tubular/pull/197>`_
 
 1.2.2 (2024-02-20)
 ------------------
@@ -75,14 +73,14 @@ Changed
 ------------------
 Added
 ^^^^^
-- Updated GroupRareLevelsTransformer so that when working with category dtypes it forgets categories encoded as rare (this is wanted behaviour as these categories are no longer present in the data) `<#177 https://github.com/lvgig/tubular/pull/177>`_
+- Updated GroupRareLevelsTransformer so that when working with category dtypes it forgets categories encoded as rare (this is wanted behaviour as these categories are no longer present in the data) `#177 <https://github.com/lvgig/tubular/pull/177>`_
 
 1.2.0 (2024-02-06)
 ------------------
 Added
 ^^^^^
 - Update OneHotEncodingTransformer to default to returning int8 columns `#175 <https://github.com/lvgig/tubular/pull/175>`_
-- Updated NullIndicator to return int8 columns `<#173 https://github.com/lvgig/tubular/pull/173>`_
+- Updated NullIndicator to return int8 columns `#173 <https://github.com/lvgig/tubular/pull/173>`_
 - Updated MeanResponseTransformer to coerce return to float (useful behaviour for category type features) `#174 <https://github.com/lvgig/tubular/pull/174>`_
 
 1.1.1 (2024-01-18)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,6 +71,11 @@ def minimal_attribute_dict():
         },
         "BaseDateTransformer": {
             "columns": ["a"],
+            "new_column_name": "bla",
+        },
+        "BaseDateTwoColumnTransformer": {
+            "columns": ["a", "b"],
+            "new_column_name": "bla",
         },
         "BaseCappingTransformer": {
             "capping_values": {"a": [0.1, 0.2]},
@@ -86,14 +91,12 @@ def minimal_attribute_dict():
             "new_col_name": "c",
         },
         "DateDiffLeapYearTransformer": {
-            "column_lower": "a",
-            "column_upper": "b",
+            "columns": ["a", "b"],
             "new_column_name": "c",
-            "drop_cols": False,
         },
         "DateDifferenceTransformer": {
-            "column_lower": "a",
-            "column_upper": "b",
+            "columns": ["a", "b"],
+            "new_column_name": "c",
         },
         "ToDatetimeTransformer": {
             "new_column_name": "b",
@@ -109,9 +112,7 @@ def minimal_attribute_dict():
         },
         "BetweenDatesTransformer": {
             "new_column_name": "c",
-            "column_lower": "a",
-            "column_upper": "b",
-            "column_between": "c",
+            "columns": ["a", "c", "b"],
         },
         "DatetimeSinusoidCalculator": {
             "columns": ["a"],

--- a/tests/dates/test_BetweenDatesTransformer.py
+++ b/tests/dates/test_BetweenDatesTransformer.py
@@ -1,103 +1,29 @@
 import datetime
 
+import pandas as pd
 import pytest
 import test_aide as ta
 
 import tests.test_data as d
-import tubular
 from tubular.dates import BetweenDatesTransformer
 
 
 class TestInit:
     "tests for BetweenDatesTransformer.__init__."
 
-    def test_super_init_called(self, mocker):
-        """Test that super.__init__ called."""
-        expected_call_args = {
-            0: {
-                "args": (),
-                "kwargs": {"columns": ["a", "b", "c"], "verbose": False},
-            },
-        }
+    @pytest.mark.parametrize("column_index", [0, 1, 2])
+    def test_columns_non_list_of_str_error(self, column_index):
+        """Test that an exception is raised if columns not list of str."""
 
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            BetweenDatesTransformer(
-                column_lower="a",
-                column_between="b",
-                column_upper="c",
-                new_column_name="d",
-                verbose=False,
-            )
-
-    def test_first_non_str_error(self):
-        """Test that an exception is raised if column_lower not str."""
+        columns = ["a", "b", "c"]
+        columns[column_index] = False
         with pytest.raises(
             TypeError,
-            match="BetweenDatesTransformer: column_lower should be str",
+            match=r"BetweenDatesTransformer: each element of columns should be a single \(string\) column name",
         ):
             BetweenDatesTransformer(
-                column_lower=False,
-                column_between="b",
-                column_upper="c",
+                columns=columns,
                 new_column_name="a",
-            )
-
-    def test_column_between_non_str_error(self):
-        """Test that an exception is raised if column_between not str."""
-        with pytest.raises(
-            TypeError,
-            match="BetweenDatesTransformer: column_between should be str",
-        ):
-            BetweenDatesTransformer(
-                column_lower="a",
-                column_between=1,
-                column_upper="c",
-                new_column_name="c",
-            )
-
-    def test_column_upper_non_str_error(self):
-        """Test that an exception is raised if column_upper not str."""
-        with pytest.raises(
-            TypeError,
-            match="BetweenDatesTransformer: column_upper should be str",
-        ):
-            BetweenDatesTransformer(
-                column_lower="a",
-                column_between="b",
-                column_upper=1.2,
-                new_column_name="c",
-            )
-
-    def test_new_column_name_non_str_error(self):
-        """Test that an exception is raised if new_column_name not str."""
-        with pytest.raises(
-            TypeError,
-            match="BetweenDatesTransformer: new_column_name should be str",
-        ):
-            BetweenDatesTransformer(
-                column_lower="a",
-                column_between="b",
-                column_upper="c",
-                new_column_name=(),
-            )
-
-    def test_lower_inclusive_non_bool_error(self):
-        """Test that an exception is raised if lower_inclusive not a bool."""
-        with pytest.raises(
-            TypeError,
-            match="BetweenDatesTransformer: lower_inclusive should be a bool",
-        ):
-            BetweenDatesTransformer(
-                column_lower="a",
-                column_between="b",
-                column_upper="c",
-                new_column_name="d",
-                lower_inclusive=1,
             )
 
     def test_upper_inclusive_non_bool_error(self):
@@ -107,37 +33,10 @@ class TestInit:
             match="BetweenDatesTransformer: upper_inclusive should be a bool",
         ):
             BetweenDatesTransformer(
-                column_lower="a",
-                column_between="b",
-                column_upper="c",
+                columns=["a", "b", "c"],
                 new_column_name="d",
                 upper_inclusive=1,
             )
-
-    def test_values_passed_in_init_set_to_attribute(self):
-        """Test that attributes are set by init."""
-        x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
-            new_column_name="d",
-            lower_inclusive=False,
-            upper_inclusive=False,
-        )
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={
-                "column_lower": "a",
-                "column_between": "b",
-                "column_upper": "c",
-                "columns": ["a", "b", "c"],
-                "new_column_name": "d",
-                "lower_inclusive": False,
-                "upper_inclusive": False,
-            },
-            msg="Attributes for BetweenDatesTransformer set in init",
-        )
 
 
 class TestTransform:
@@ -183,58 +82,36 @@ class TestTransform:
 
         return df
 
-    def test_super_transform_call(self, mocker):
-        """Test that call the BaseTransformer.transform() is as expected."""
-        df = d.create_is_between_dates_df_1()
-
-        x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
-            new_column_name="d",
-        )
-
-        expected_call_args = {
-            0: {"args": (d.create_is_between_dates_df_1(),), "kwargs": {}},
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "transform",
-            expected_call_args,
-            return_value=d.create_is_between_dates_df_1(),
-        ):
-            x.transform(df)
-
     @pytest.mark.parametrize(
         ("columns, bad_col"),
         [
-            (["date_col", "numeric_col", "date_col"], 1),
-            (["date_col", "string_col", "date_col"], 1),
-            (["date_col", "bool_col", "date_col"], 1),
-            (["date_col", "empty_col", "date_col"], 1),
-            (["numeric_col", "date_col", "date_col"], 0),
-            (["string_col", "date_col", "date_col"], 0),
-            (["bool_col", "date_col", "date_col"], 0),
-            (["empty_col", "date_col", "date_col"], 0),
-            (["date_col", "date_col", "numeric_col"], 2),
-            (["date_col", "date_col", "string_col"], 2),
-            (["date_col", "date_col", "bool_col"], 2),
-            (["date_col", "date_col", "empty_col"], 2),
+            (["date_col", "numeric_col", "date_col2"], 1),
+            (["date_col", "string_col", "date_col2"], 1),
+            (["date_col", "bool_col", "date_col2"], 1),
+            (["date_col", "empty_col", "date_col2"], 1),
+            (["numeric_col", "date_col", "date_col2"], 0),
+            (["string_col", "date_col", "date_col2"], 0),
+            (["bool_col", "date_col", "date_col2"], 0),
+            (["empty_col", "date_col", "date_col2"], 0),
+            (["date_col", "date_col2", "numeric_col"], 2),
+            (["date_col", "date_col2", "string_col"], 2),
+            (["date_col", "date_col2", "bool_col"], 2),
+            (["date_col", "date_col2", "empty_col"], 2),
         ],
     )
     def test_input_data_check_column_errors(self, columns, bad_col):
         """Check that errors are raised on a variety of different non date datatypes"""
         x = BetweenDatesTransformer(
-            column_lower=columns[0],
-            column_between=columns[1],
-            column_upper=columns[2],
+            columns=columns,
             new_column_name="d",
         )
         df = d.create_date_diff_incorrect_dtypes()
+        # types don't seem to come out of the above function as expected, hard enforce
+        df["date_col"] = pd.to_datetime(df["date_col"])
+        df["date_col2"] = df["date_col"].copy()
+        df = df[columns]
 
-        msg = f"{x.classname()}: {columns[bad_col]} should be datetime64 or date type but got {df[columns[bad_col]].dtype}"
+        msg = rf"{x.classname()}: {columns[bad_col]} type should be in \['datetime64', 'date'\] but got {df[columns[bad_col]].dtype}"
 
         with pytest.raises(TypeError, match=msg):
             x.transform(df)
@@ -249,9 +126,7 @@ class TestTransform:
     def test_output(self, df, expected):
         """Test the output of transform is as expected."""
         x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
+            columns=["a", "b", "c"],
             new_column_name="d",
             lower_inclusive=False,
             upper_inclusive=False,
@@ -275,9 +150,7 @@ class TestTransform:
     def test_output_both_exclusive(self, df, expected):
         """Test the output of transform is as expected if both limits are exclusive."""
         x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
+            columns=["a", "b", "c"],
             new_column_name="e",
             lower_inclusive=False,
             upper_inclusive=False,
@@ -301,9 +174,7 @@ class TestTransform:
     def test_output_lower_exclusive(self, df, expected):
         """Test the output of transform is as expected if the lower limits are exclusive only."""
         x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
+            columns=["a", "b", "c"],
             new_column_name="e",
             lower_inclusive=False,
             upper_inclusive=True,
@@ -327,9 +198,7 @@ class TestTransform:
     def test_output_upper_exclusive(self, df, expected):
         """Test the output of transform is as expected if the upper limits are exclusive only."""
         x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
+            columns=["a", "b", "c"],
             new_column_name="e",
             lower_inclusive=True,
             upper_inclusive=False,
@@ -353,9 +222,7 @@ class TestTransform:
     def test_output_both_inclusive(self, df, expected):
         """Test the output of transform is as expected if the both limits are inclusive."""
         x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
+            columns=["a", "b", "c"],
             new_column_name="e",
             lower_inclusive=True,
             upper_inclusive=True,
@@ -372,9 +239,7 @@ class TestTransform:
     def test_warning_message(self):
         """Test a warning is generated if not all the values in column_upper are greater than or equal to column_lower."""
         x = BetweenDatesTransformer(
-            column_lower="a",
-            column_between="b",
-            column_upper="c",
+            columns=["a", "b", "c"],
             new_column_name="e",
             lower_inclusive=True,
             upper_inclusive=True,
@@ -401,9 +266,7 @@ class TestTransform:
     def test_output_different_date_dtypes(self, columns):
         """Test the output of transform is as expected if both limits are exclusive."""
         x = BetweenDatesTransformer(
-            column_lower=columns[0],
-            column_between=columns[1],
-            column_upper=columns[2],
+            columns=columns,
             new_column_name="e",
             lower_inclusive=False,
             upper_inclusive=False,

--- a/tests/dates/test_ToDatetimeTransformer.py
+++ b/tests/dates/test_ToDatetimeTransformer.py
@@ -1,48 +1,22 @@
 import datetime
 
 import numpy as np
-import pandas
 import pandas as pd
 import pytest
 import test_aide as ta
 
 import tests.test_data as d
-import tubular
 from tubular.dates import ToDatetimeTransformer
 
 
 class TestInit:
     """Tests for ToDatetimeTransformer.init()."""
 
-    def test_super_init_called(self, mocker):
-        """Test that init calls BaseTransformer.init."""
-        expected_call_args = {
-            0: {
-                "args": (),
-                "kwargs": {
-                    "columns": ["a"],
-                    "verbose": False,
-                },
-            },
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            ToDatetimeTransformer(
-                column="a",
-                new_column_name="b",
-                verbose=False,
-            )
-
     def test_column_type_error(self):
         """Test that an exception is raised if column is not a str."""
         with pytest.raises(
             TypeError,
-            match="ToDatetimeTransformer: column should be a single str giving the column to transform to datetime",
+            match=r"ToDatetimeTransformer: each element of columns should be a single \(string\) column name",
         ):
             ToDatetimeTransformer(
                 column=["a"],
@@ -53,7 +27,7 @@ class TestInit:
         """Test that an exception is raised if new_column_name is not a str."""
         with pytest.raises(
             TypeError,
-            match="ToDatetimeTransformer: new_column_name must be a str",
+            match="ToDatetimeTransformer: new_column_name should be str",
         ):
             ToDatetimeTransformer(column="b", new_column_name=1)
 
@@ -124,69 +98,6 @@ class TestTransform:
                 ],
             },
         )
-
-    def test_super_transform_call(self, mocker):
-        """Test the call to BaseTransformer.transform is as expected."""
-        df = d.create_datediff_test_df()
-
-        to_dt = ToDatetimeTransformer(column="a", new_column_name="Y")
-
-        expected_call_args = {0: {"args": (d.create_datediff_test_df(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "transform",
-            expected_call_args,
-            return_value=d.create_datediff_test_df(),
-        ):
-            to_dt.transform(df)
-
-    def test_to_datetime_call(self, mocker):
-        """Test the call to pandas.to_datetime is as expected."""
-        df = d.create_to_datetime_test_df()
-
-        to_dt = ToDatetimeTransformer(
-            column="a",
-            new_column_name="a_Y",
-            to_datetime_kwargs={"format": "%Y"},
-        )
-
-        expected_call_args = {
-            0: {
-                "args": (d.create_to_datetime_test_df()["a"],),
-                "kwargs": {"format": "%Y"},
-            },
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            pandas,
-            "to_datetime",
-            expected_call_args,
-            return_value=pd.to_datetime(d.create_to_datetime_test_df()["a"]),
-        ):
-            to_dt.transform(df)
-
-    def test_output_from_to_datetime_assigned_to_column(self, mocker):
-        """Test that the output from pd.to_datetime is assigned to column with name new_column_name."""
-        df = d.create_to_datetime_test_df()
-
-        to_dt = ToDatetimeTransformer(
-            column="a",
-            new_column_name="a_new",
-            to_datetime_kwargs={"format": "%Y"},
-        )
-
-        to_datetime_output = [1, 2, 3, 4, 5, 6]
-
-        mocker.patch("pandas.to_datetime", return_value=to_datetime_output)
-
-        df_transformed = to_dt.transform(df)
-
-        assert (
-            df_transformed["a_new"].tolist() == to_datetime_output
-        ), "unexpected values assigned to a_new column"
 
     @pytest.mark.parametrize(
         ("df", "expected"),


### PR DESCRIPTION
…better follow existing base class format (validate at init/fit/transform). Made transformers more opinionated on types to reduce complexity, and standardised common arguments across transformers.

Fixed tests for new setting, but just removed e.g. assert call tests that we will no longer be interested in post test refactor.

[Issue](https://github.com/lvgig/tubular/issues/213)