### PR TITLE
Create BaseDropOriginalMixin Class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,8 @@ Moved tests for these objects to new approach.
 - Refactored ModeImputer tests in new format.
 - Added generic init tests to base tests for transformers that take two columns as an input.
 - Refactored EqualityChecker tests in new format.
-- Bugfix to MeanResponseTransformer to ignore unobserved categorical levels
+- Bugfix to MeanResponseTransformer to ignore unobserved categorical levels.
+- Added BaseDropOriginalMixin to mixin transformers to handle validation and method of dropping original features, also added appropriate test classes.
 
 
 Removed

--- a/tests/base/test_DataFrameMethodTransformer.py
+++ b/tests/base/test_DataFrameMethodTransformer.py
@@ -8,6 +8,8 @@ import test_aide as ta
 import tests.test_data as d
 from tests.base_tests import (
     ColumnStrListInitTests,
+    DropOriginalInitTests,
+    DropOriginalTransformTests,
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
@@ -83,25 +85,8 @@ class DataFrameMethodTransformerInitTests(ColumnStrListInitTests):
                 columns=["b", "c"],
             )
 
-    @pytest.mark.parametrize("not_bool", [{"a": 1}, [1, 2], 1, "True", 1.5])
-    def test_exception_raised_drop_original_not_bool(self, not_bool):
-        """Test an exception is raised if drop_original is not a string"""
 
-        with pytest.raises(
-            TypeError,
-            match=re.escape(
-                "DataFrameMethodTransformer: drop_original should be bool",
-            ),
-        ):
-            DataFrameMethodTransformer(
-                new_column_names="a",
-                pd_method_name="sum",
-                columns=["b", "c"],
-                drop_original=not_bool,
-            )
-
-
-class TestInit(DataFrameMethodTransformerInitTests):
+class TestInit(DropOriginalInitTests, DataFrameMethodTransformerInitTests):
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "DataFrameMethodTransformer"
@@ -115,7 +100,7 @@ class TestFit(GenericFitTests):
         cls.transformer_name = "DataFrameMethodTransformer"
 
 
-class TestTransform(GenericTransformTests):
+class TestTransform(DropOriginalTransformTests, GenericTransformTests):
     """Tests for DataFrameMethodTransformer.transform()."""
 
     @classmethod
@@ -186,44 +171,6 @@ class TestTransform(GenericTransformTests):
             actual=df_transformed,
             msg="DataFrameMethodTransformer divide by 2 columns b and c",
         )
-
-    def test_original_columns_dropped_when_specified(self):
-        """Test DataFrameMethodTransformer.transform drops original columns get when specified."""
-        df = d.create_df_3()
-
-        x = DataFrameMethodTransformer(
-            new_column_names="a_b_sum",
-            pd_method_name="sum",
-            columns=["a", "b"],
-            drop_original=True,
-        )
-
-        x.fit(df)
-
-        df_transformed = x.transform(df)
-
-        assert ("a" not in df_transformed.columns.to_numpy()) and (
-            "b" not in df_transformed.columns.to_numpy()
-        ), "original columns not dropped"
-
-    def test_original_columns_kept_when_specified(self):
-        """Test DataFrameMethodTransformer.transform keeps original columns when specified."""
-        df = d.create_df_3()
-
-        x = DataFrameMethodTransformer(
-            new_column_names="a_b_sum",
-            pd_method_name="sum",
-            columns=["a", "b"],
-            drop_original=False,
-        )
-
-        x.fit(df)
-
-        df_transformed = x.transform(df)
-
-        assert ("a" in df_transformed.columns.to_numpy()) and (
-            "b" in df_transformed.columns.to_numpy()
-        ), "original columns not kept"
 
 
 class TestOtherBaseBehaviour(OtherBaseBehaviourTests):

--- a/tests/base/test_DataFrameMethodTransformer.py
+++ b/tests/base/test_DataFrameMethodTransformer.py
@@ -90,7 +90,7 @@ class DataFrameMethodTransformerInitTests(ColumnStrListInitTests):
         with pytest.raises(
             TypeError,
             match=re.escape(
-                f"DataFrameMethodTransformer: unexpected type ({type(not_bool)}) for drop_original, expecting bool",
+                "DataFrameMethodTransformer: drop_original should be bool",
             ),
         ):
             DataFrameMethodTransformer(

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -120,6 +120,30 @@ class ColumnStrListInitTests(GenericInitTests):
             uninitialized_transformers[self.transformer_name](**args)
 
 
+class DropOriginalInitTests(GenericInitTests):
+    """
+    Tests for BaseTransformer.init() behaviour specific to when a transformer accepts a "drop_original" column.
+    Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
+    """
+
+    @pytest.mark.parametrize("drop_orginal_column", (0, "a", ["a"], {"a": 10}, None))
+    def test_drop_column_arg_errors(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+        drop_orginal_column,
+    ):
+        """Test that appropriate errors are throwm for non boolean arg."""
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["drop_original"] = drop_orginal_column
+
+        with pytest.raises(
+            TypeError,
+            match=f"{self.transformer_name}: drop_original should be bool",
+        ):
+            uninitialized_transformers[self.transformer_name](**args)
+
+
 class WeightColumnInitTests(GenericInitTests):
     """
     Tests for BaseTransformer.init() behaviour specific to when a transformer takes accepts a weight column.
@@ -527,6 +551,48 @@ class GenericTransformTests:
         _ = x.transform(df)
 
         pd.testing.assert_frame_equal(df, d.create_df_3())
+
+
+class DropOriginalTransformTests(GenericTransformTests):
+    """
+    Transform tests for transformers that take a "drop_original" argument
+    Note this deliberately avoids starting with "Tests" so that the tests are not run on import.
+    """
+
+    def test_original_columns_dropped_when_specified(
+        self,
+        initialized_transformers,
+    ):
+        """Test transformer drops original columns when specified."""
+
+        df = d.create_df_3()
+
+        x = initialized_transformers[self.transformer_name]
+
+        x.columns = ["a", "b"]
+        x.drop_original = True
+
+        df_transformed = x.transform(df)
+
+        assert ("a" not in df_transformed.columns.to_numpy()) and (
+            "b" not in df_transformed.columns.to_numpy()
+        ), "original columns not dropped"
+
+    def test_original_columns_kept_when_specified(self, initialized_transformers):
+        """Test transformer keeps original columns when specified."""
+
+        df = d.create_df_3()
+
+        x = initialized_transformers[self.transformer_name]
+
+        x.columns = ["a", "b"]
+        x.drop_original = False
+
+        df_transformed = x.transform(df)
+
+        assert ("a" in df_transformed.columns.to_numpy()) and (
+            "b" in df_transformed.columns.to_numpy()
+        ), "original columns not kept"
 
 
 class ColumnsCheckTests:

--- a/tests/comparison/test_EqualityChecker.py
+++ b/tests/comparison/test_EqualityChecker.py
@@ -1,10 +1,9 @@
-import re
-
 import pytest
 import test_aide as ta
 
 import tests.test_data as d
 from tests.base_tests import (
+    DropOriginalInitTests,
     GenericFitTests,
     GenericTransformTests,
     OtherBaseBehaviourTests,
@@ -13,28 +12,12 @@ from tests.base_tests import (
 from tubular.comparison import EqualityChecker
 
 
-class TestInit(TwoColumnListInitTests):
+class TestInit(DropOriginalInitTests, TwoColumnListInitTests):
     """Generic tests for transformer.init()."""
 
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "EqualityChecker"
-
-    @pytest.mark.parametrize("not_bool", [{"a": 1}, [1, 2], 1, "True", 1.5])
-    def test_exception_raised_drop_original_not_bool(self, not_bool):
-        """Test an exception is raised if drop_original is not a boolean"""
-
-        with pytest.raises(
-            TypeError,
-            match=re.escape(
-                "EqualityChecker: drop_original should be bool",
-            ),
-        ):
-            EqualityChecker(
-                new_col_name="a",
-                columns=["b", "c"],
-                drop_original=not_bool,
-            )
 
 
 class TestFit(GenericFitTests):

--- a/tests/comparison/test_EqualityChecker.py
+++ b/tests/comparison/test_EqualityChecker.py
@@ -22,7 +22,7 @@ class TestInit(TwoColumnListInitTests):
 
     @pytest.mark.parametrize("not_bool", [{"a": 1}, [1, 2], 1, "True", 1.5])
     def test_exception_raised_drop_original_not_bool(self, not_bool):
-        """Test an exception is raised if drop_original is not a string"""
+        """Test an exception is raised if drop_original is not a boolean"""
 
         with pytest.raises(
             TypeError,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,7 @@ def minimal_attribute_dict():
             "columns": ["a", "c"],
             "new_column_names": "f",
             "pd_method_name": "sum",
+            "drop_original": True,
         },
         "BaseDateTransformer": {
             "columns": ["a"],
@@ -84,6 +85,7 @@ def minimal_attribute_dict():
         "EqualityChecker": {
             "columns": ["a", "b"],
             "new_col_name": "c",
+            "drop_original": True,
         },
         "DateDiffLeapYearTransformer": {
             "column_lower": "a",
@@ -194,6 +196,7 @@ def minimal_attribute_dict():
         },
         "OneHotEncodingTransformer": {
             "columns": ["c"],
+            "drop_original": True,
         },
         "LogTransformer": {
             "columns": ["a"],

--- a/tubular/comparison.py
+++ b/tubular/comparison.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import pandas as pd  # noqa: TCH002
 
 from tubular.base import BaseTransformer
+from tubular.mixins import BaseDropOriginalMixin
 
 
-class EqualityChecker(BaseTransformer):
+class EqualityChecker(BaseDropOriginalMixin, BaseTransformer):
     """Transformer to check if two columns are equal.
 
     Parameters
@@ -45,12 +46,9 @@ class EqualityChecker(BaseTransformer):
             msg = f"{self.classname()}: new_col_name should be str"
             raise TypeError(msg)
 
-        if not (isinstance(drop_original, bool)):
-            msg = f"{self.classname()}: drop_original should be bool"
-            raise TypeError(msg)
-
         self.new_col_name = new_col_name
-        self.drop_original = drop_original
+
+        BaseDropOriginalMixin.set_drop_original_column(self, drop_original)
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
         """Create a column which is populated by the boolean
@@ -71,8 +69,12 @@ class EqualityChecker(BaseTransformer):
 
         X[self.new_col_name] = X[self.columns[0]] == X[self.columns[1]]
 
-        if self.drop_original:
-            for col in self.columns:
-                del X[col]
+        # Drop original columns
+        BaseDropOriginalMixin.drop_original_column(
+            self,
+            X,
+            self.drop_original,
+            self.columns,
+        )
 
         return X

--- a/tubular/mixins.py
+++ b/tubular/mixins.py
@@ -1,5 +1,63 @@
+from __future__ import annotations
+
 import numpy as np
 import pandas as pd
+
+
+class BaseDropOriginalMixin:
+    """Mixin class to validate and apply 'drop_original' argument used by various transformers.
+
+    Transformer deletes transformer input columns depending on boolean argument.
+
+    """
+
+    def set_drop_original_column(self, drop_original: bool) -> None:
+        """Helper method for validating 'drop_original' argument.
+
+        Parameters
+        ----------
+        drop_original : bool
+            boolean dictating dropping the input columns from X after checks.
+
+        """
+        # check if 'drop_original' argument is boolean
+        if type(drop_original) is not bool:
+            msg = f"{self.classname()}: unexpected type ({type(drop_original)}) for drop_original, expecting bool"
+            raise TypeError(msg)
+
+        self.drop_original = drop_original
+
+    def drop_original_column(
+        self,
+        X: pd.DataFrame,
+        drop_original: bool,
+        columns: list[str] | str | None,
+    ) -> pd.DataFrame:
+        """Method for dropping input columns from X if drop_original set to True.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Data with columns to drop.
+
+        drop_original : bool
+            boolean dictating dropping the input columns from X after checks.
+
+        columns: list[str] | str |  None
+            Object containing columns to drop
+
+        Returns
+        -------
+        X : pd.DataFrame
+            Transformed input X with columns dropped.
+
+        """
+
+        if drop_original:
+            for col in columns:
+                del X[col]
+
+        return X
 
 
 class WeightColumnMixin:

--- a/tubular/mixins.py
+++ b/tubular/mixins.py
@@ -22,7 +22,7 @@ class BaseDropOriginalMixin:
         """
         # check if 'drop_original' argument is boolean
         if type(drop_original) is not bool:
-            msg = f"{self.classname()}: unexpected type ({type(drop_original)}) for drop_original, expecting bool"
+            msg = f"{self.classname()}: drop_original should be bool"
             raise TypeError(msg)
 
         self.drop_original = drop_original


### PR DESCRIPTION
As per ticket [here](https://github.com/lvgig/tubular/issues/243)

- Added mixin class for transformers that take 'drop_original' argument. 
- Added this class to mixin script as per weight class mixin script created during test refactor.
- Added associated tests to the base tests file rather than creating a new script specifically for this (as per weight class mixin also)
- Updated transformers to inherit from new mixin class where required
- Updated test files to inherit from new mixin test class where required and where refactor has taken place