### PR TITLE
set up minimal_dataframe_dict fixture and integrated into generic tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,7 +51,7 @@ Changed
 - Added BaseDropOriginalMixin to mixin transformers to handle validation and method of dropping original features, also added appropriate test classes.
 - Refactored MeanImputer tests in new format `#250 <https://github.com/lvgig/tubular/pull/250>`_
 - Refactored DatetimeInfoExtractor to condense and improve readability
-- added minimal_dataframe_dict fixture to conftest, and edited generic tests to use this
+- added minimal_dataframe_lookup fixture to conftest, and edited generic tests to use this
 
 
 Removed

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Changed
 - Added BaseDropOriginalMixin to mixin transformers to handle validation and method of dropping original features, also added appropriate test classes.
 - Refactored MeanImputer tests in new format `#250 <https://github.com/lvgig/tubular/pull/250>`_
 - Refactored DatetimeInfoExtractor to condense and improve readability
+- added minimal_dataframe_dict fixture to conftest, and edited generic tests to use this
 
 
 Removed

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -1,4 +1,5 @@
 # tests to apply to all columns str or list transformers
+import copy
 import re
 
 import numpy as np
@@ -247,10 +248,11 @@ class GenericFitTests:
     def test_fit_returns_self(
         self,
         initialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test fit returns self?."""
 
-        df = d.create_numeric_df_1()
+        df = minimal_dataframe_dict[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 
@@ -263,17 +265,19 @@ class GenericFitTests:
     def test_fit_not_changing_data(
         self,
         initialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test fit does not change X."""
 
-        df = d.create_df_2()
+        df = minimal_dataframe_dict[self.transformer_name]
+        original_df = copy.deepcopy(df)
 
         x = initialized_transformers[self.transformer_name]
 
         x.fit(df)
 
         ta.equality.assert_equal_dispatch(
-            expected=d.create_df_2(),
+            expected=original_df,
             actual=df,
             msg="Check X not changing during fit",
         )
@@ -368,11 +372,15 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         minimal_attribute_dict,
         uninitialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test fit returns self?."""
-        df = d.create_df_9()
+        df = minimal_dataframe_dict[self.transformer_name]
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = "c"
+        # insert weight column
+        weight_column = "weight_column"
+        args["weights_column"] = weight_column
+        df[weight_column] = np.arange(1, len(df) + 1)
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
 
@@ -386,18 +394,24 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         minimal_attribute_dict,
         uninitialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test fit does not change X - when weights are used."""
-        df = d.create_df_9()
+        df = minimal_dataframe_dict[self.transformer_name]
+        # insert weight column
+        weight_column = "weight_column"
+        df[weight_column] = np.arange(1, len(df) + 1)
+
+        original_df = copy.deepcopy(df)
 
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = "c"
+        args["weights_column"] = weight_column
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
 
         transformer.fit(df)
         ta.equality.assert_equal_dispatch(
-            expected=d.create_df_9(),
+            expected=original_df,
             actual=df,
             msg=f"X changed during fit for {self.transformer_name}",
         )
@@ -417,20 +431,20 @@ class WeightColumnFitTests(GenericFitTests):
         expected_message,
         minimal_attribute_dict,
         uninitialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test that an exception is raised if there are negative/nan/inf values in sample_weight."""
 
+        df = minimal_dataframe_dict[self.transformer_name]
+
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = "w"
+        weight_column = "weight_column"
+        args["weights_column"] = weight_column
+
+        df[weight_column] = np.arange(1, len(df) + 1)
+        df.iloc[0, df.columns.get_loc(weight_column)] = bad_weight_value
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
-
-        df = pd.DataFrame(
-            {
-                "a": [1, 2, 3],
-                "w": [1, 1, bad_weight_value],
-            },
-        )
 
         with pytest.raises(ValueError, match=expected_message):
             transformer.fit(df)
@@ -449,16 +463,19 @@ class WeightColumnFitTests(GenericFitTests):
             ),
         ]
 
-    @pytest.mark.parametrize("df, error, col", get_df_error_combos())
-    def test_weight_not_in_X_error(
+    def test_weight_col_non_numeric(
         self,
-        df,
-        error,
-        col,
         uninitialized_transformers,
         minimal_attribute_dict,
+        minimal_dataframe_dict,
     ):
-        """Test an error is raised if weight is not in X or weight is not numeric."""
+        """Test an error is raised if weight is not numeric."""
+
+        df = minimal_dataframe_dict[self.transformer_name]
+
+        weight_column = "weight_column"
+        error = r"weight column must be numeric."
+        df[weight_column] = ["a"] * len(df)
 
         with pytest.raises(
             ValueError,
@@ -467,7 +484,32 @@ class WeightColumnFitTests(GenericFitTests):
             # using check_weights_column method to test correct error is raised for transformers that use weights
 
             args = minimal_attribute_dict[self.transformer_name].copy()
-            args["weights_column"] = col
+            args["weights_column"] = weight_column
+
+            transformer = uninitialized_transformers[self.transformer_name](**args)
+            transformer.fit(df)
+
+    def test_weight_not_in_X_error(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+        minimal_dataframe_dict,
+    ):
+        """Test an error is raised if weight is not in X"""
+
+        df = minimal_dataframe_dict[self.transformer_name]
+
+        weight_column = "weight_column"
+        error = rf"weight col \({weight_column}\) is not present in columns of data"
+
+        with pytest.raises(
+            ValueError,
+            match=error,
+        ):
+            # using check_weights_column method to test correct error is raised for transformers that use weights
+
+            args = minimal_attribute_dict[self.transformer_name].copy()
+            args["weights_column"] = weight_column
 
             transformer = uninitialized_transformers[self.transformer_name](**args)
             transformer.fit(df)
@@ -476,18 +518,16 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         minimal_attribute_dict,
         uninitialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test that an exception is raised if the total sample weights are 0."""
 
         args = minimal_attribute_dict[self.transformer_name].copy()
-        args["weights_column"] = "w"
+        weight_column = "weight_column"
+        args["weights_column"] = weight_column
 
-        df = pd.DataFrame(
-            {
-                "a": [1, 2, 3],
-                "w": [0, 0, 0],
-            },
-        )
+        df = minimal_dataframe_dict[self.transformer_name]
+        df[weight_column] = [0] * len(df)
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
         with pytest.raises(
@@ -539,10 +579,15 @@ class GenericTransformTests:
         ):
             x.transform(df)
 
-    def test_original_df_not_updated(self, initialized_transformers):
+    def test_original_df_not_updated(
+        self,
+        initialized_transformers,
+        minimal_dataframe_dict,
+    ):
         """Test that the original dataframe is not transformed when transform method used."""
 
-        df = d.create_df_3()
+        df = minimal_dataframe_dict[self.transformer_name]
+        original_df = copy.deepcopy(df)
 
         x = initialized_transformers[self.transformer_name]
 
@@ -550,7 +595,7 @@ class GenericTransformTests:
 
         _ = x.transform(df)
 
-        pd.testing.assert_frame_equal(df, d.create_df_3())
+        pd.testing.assert_frame_equal(df, original_df)
 
 
 class DropOriginalTransformTests(GenericTransformTests):
@@ -562,42 +607,47 @@ class DropOriginalTransformTests(GenericTransformTests):
     def test_original_columns_dropped_when_specified(
         self,
         initialized_transformers,
+        minimal_dataframe_dict,
     ):
         """Test transformer drops original columns when specified."""
 
-        df = d.create_df_3()
+        df = minimal_dataframe_dict[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 
-        x.columns = ["a", "b"]
         x.drop_original = True
 
         df_transformed = x.transform(df)
+        remaining_cols = df_transformed.columns.to_numpy()
+        for col in x.columns:
+            assert col not in remaining_cols, "original columns not dropped"
 
-        assert ("a" not in df_transformed.columns.to_numpy()) and (
-            "b" not in df_transformed.columns.to_numpy()
-        ), "original columns not dropped"
-
-    def test_original_columns_kept_when_specified(self, initialized_transformers):
+    def test_original_columns_kept_when_specified(
+        self,
+        initialized_transformers,
+        minimal_dataframe_dict,
+    ):
         """Test transformer keeps original columns when specified."""
 
-        df = d.create_df_3()
+        df = minimal_dataframe_dict[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 
-        x.columns = ["a", "b"]
         x.drop_original = False
 
         df_transformed = x.transform(df)
+        remaining_cols = df_transformed.columns.to_numpy()
+        for col in x.columns:
+            assert col in remaining_cols, "original columns not kept"
 
-        assert ("a" in df_transformed.columns.to_numpy()) and (
-            "b" in df_transformed.columns.to_numpy()
-        ), "original columns not kept"
-
-    def test_other_columns_not_modified(self, initialized_transformers):
+    def test_other_columns_not_modified(
+        self,
+        initialized_transformers,
+        minimal_dataframe_dict,
+    ):
         """Test transformer does not modify unspecified columns."""
 
-        df = d.create_df_3()
+        df = minimal_dataframe_dict[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 

--- a/tests/base_tests.py
+++ b/tests/base_tests.py
@@ -248,11 +248,11 @@ class GenericFitTests:
     def test_fit_returns_self(
         self,
         initialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test fit returns self?."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 
@@ -265,11 +265,11 @@ class GenericFitTests:
     def test_fit_not_changing_data(
         self,
         initialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test fit does not change X."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
         original_df = copy.deepcopy(df)
 
         x = initialized_transformers[self.transformer_name]
@@ -372,10 +372,10 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         minimal_attribute_dict,
         uninitialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test fit returns self?."""
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
         args = minimal_attribute_dict[self.transformer_name].copy()
         # insert weight column
         weight_column = "weight_column"
@@ -394,10 +394,10 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         minimal_attribute_dict,
         uninitialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test fit does not change X - when weights are used."""
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
         # insert weight column
         weight_column = "weight_column"
         df[weight_column] = np.arange(1, len(df) + 1)
@@ -431,11 +431,11 @@ class WeightColumnFitTests(GenericFitTests):
         expected_message,
         minimal_attribute_dict,
         uninitialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test that an exception is raised if there are negative/nan/inf values in sample_weight."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         args = minimal_attribute_dict[self.transformer_name].copy()
         weight_column = "weight_column"
@@ -467,11 +467,11 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         uninitialized_transformers,
         minimal_attribute_dict,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test an error is raised if weight is not numeric."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         weight_column = "weight_column"
         error = r"weight column must be numeric."
@@ -493,11 +493,11 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         uninitialized_transformers,
         minimal_attribute_dict,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test an error is raised if weight is not in X"""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         weight_column = "weight_column"
         error = rf"weight col \({weight_column}\) is not present in columns of data"
@@ -518,7 +518,7 @@ class WeightColumnFitTests(GenericFitTests):
         self,
         minimal_attribute_dict,
         uninitialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test that an exception is raised if the total sample weights are 0."""
 
@@ -526,7 +526,7 @@ class WeightColumnFitTests(GenericFitTests):
         weight_column = "weight_column"
         args["weights_column"] = weight_column
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
         df[weight_column] = [0] * len(df)
 
         transformer = uninitialized_transformers[self.transformer_name](**args)
@@ -582,11 +582,11 @@ class GenericTransformTests:
     def test_original_df_not_updated(
         self,
         initialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test that the original dataframe is not transformed when transform method used."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
         original_df = copy.deepcopy(df)
 
         x = initialized_transformers[self.transformer_name]
@@ -607,11 +607,11 @@ class DropOriginalTransformTests(GenericTransformTests):
     def test_original_columns_dropped_when_specified(
         self,
         initialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test transformer drops original columns when specified."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 
@@ -625,11 +625,11 @@ class DropOriginalTransformTests(GenericTransformTests):
     def test_original_columns_kept_when_specified(
         self,
         initialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test transformer keeps original columns when specified."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 
@@ -643,11 +643,11 @@ class DropOriginalTransformTests(GenericTransformTests):
     def test_other_columns_not_modified(
         self,
         initialized_transformers,
-        minimal_dataframe_dict,
+        minimal_dataframe_lookup,
     ):
         """Test transformer does not modify unspecified columns."""
 
-        df = minimal_dataframe_dict[self.transformer_name]
+        df = minimal_dataframe_lookup[self.transformer_name]
 
         x = initialized_transformers[self.transformer_name]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import pkgutil
 from importlib import import_module
@@ -31,7 +33,27 @@ New transformers will need to be added to minimal_attribute_dict.
  """
 
 
-def get_all_classes(wanted_module=None):
+def get_all_classes(
+    wanted_module: str | None = None,
+) -> dict[str, base.BaseTransformer]:
+    """Method to call the weighted_quantile method and prepare the outputs.
+
+    If there are no None values in the supplied quantiles then the outputs from weighted_quantile
+    are returned as is. If there are then prepare_quantiles removes the None values before
+    calling weighted_quantile and adds them back into the output, in the same position, after
+    calling.
+
+    Parameters
+    ----------
+    wanted_module : str or None
+        str indicating which module to load classes from (e.g. 'tubular.dates'). If none, loads from all modules.
+
+    Returns
+    -------
+    all_classes : dict[str, BaseTransformer]
+        Dictionary containing classes in format {transformer_name:transformer}
+
+    """
     root = str(Path(__file__).parent.parent)
 
     all_classes = []
@@ -248,7 +270,7 @@ def minimal_attribute_dict():
 
 
 @pytest.fixture()
-def minimal_dataframe_dict():
+def minimal_dataframe_lookup():
     """links transformers to minimal dataframes needed to successfully run transformer.
     New transformers need to be added here"""
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -34,6 +34,17 @@ def create_numeric_df_1():
     )
 
 
+def create_object_df():
+    """Example with object columns - c is numeric target"""
+    return pd.DataFrame(
+        {
+            "a": ["a", "b", "c", "d", "e"],
+            "b": ["f", "g", "h", "i", "j"],
+            "c": [1, 2, 3, 4, 5],
+        },
+    )
+
+
 def create_df_1():
     """Create simple DataFrame with the following...
 


### PR DESCRIPTION
Set up minimal_dataframe_dict fixture to make it easier to manage generic tests. Refactored existing generic tests to use this approach