### PR TITLE
switch to setuptools-git-versioning over setuptools-scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,15 @@
 requires = [
     "setuptools >= 61.0",
     "wheel",
-    "setuptools-scm[toml]>=6.0"
+    "setuptools-git-versioning>=2.0<3"
    ]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["tubular"]
 
-[tool.setuptools_scm]
-# can be empty if no extra settings are needed, presence enables setuptools_scm
+[tool.setuptools-git-versioning]
+enabled = true # Allows setuptools-git-versioning to pull version from git state
 
 [project]
 name = "tubular"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 61.0",
     "wheel",
-    "setuptools-git-versioning>=2.0<3"
+    "setuptools-git-versioning>=2.0,<3"
    ]
 build-backend = "setuptools.build_meta"
 

--- a/tubular/__init__.py
+++ b/tubular/__init__.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
 from tubular import (
     base,
@@ -13,5 +13,5 @@ from tubular import (
     strings,
 )
 
-with suppress(ModuleNotFoundError):
+with suppress(PackageNotFoundError):
     __version__ = version("tubular")


### PR DESCRIPTION
setup tools scm automatic versioning with every commit seems useful in the context of continuous deployment but i would propose we switch to the slightly neater setuptools-git-versioning (i.e. version bump only on tags) until such a time as we aree ready to move to continuous deployment.