### PR TITLE
update upload-artifact GH action version

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload coverage pytest html test results to github
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-html-pytest-results
           path: htmlcov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload coverage pytest html test results to github
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: coverage-html-pytest-results
           path: htmlcov


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Pipeline is currently failing due to this deprecation.  Updated actions/upload-artifact@v2 to v4 (latest)