### PR TITLE
298 refactor DatetimeSinusoidCalculator tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changed
 - As part of above, edited dates file transformers to use BaseDropOriginalMixin in transform
 - Refactored DateDiffLeapYearTransformer tests in new format. As part of this had to remove the autodefined new_column_name, as this conflicts with the generic testing. Suggest we look to turn back on in future. `#295 https://github.com/lvgig/tubular/issues/295`
 - Edited base testing setup for dates file, created new BaseDatetimeTransformer class
+- Refactored DatetimeSinusoidCalculator tests in new format. `#298 <https://github.com/lvgig/tubular/issues/298>`_
 
 
 1.3.1 (2024-07-18)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,7 +37,7 @@ Changed
 - As part of above, edited dates file transformers to use BaseDropOriginalMixin in transform
 - Refactored DateDiffLeapYearTransformer tests in new format. As part of this had to remove the autodefined new_column_name, as this conflicts with the generic testing. Suggest we look to turn back on in future. `#295 https://github.com/lvgig/tubular/issues/295`
 - Edited base testing setup for dates file, created new BaseDatetimeTransformer class
-- Refactored DatetimeSinusoidCalculator tests in new format. `#298 <https://github.com/lvgig/tubular/issues/298>`_
+- Refactored DatetimeSinusoidCalculator tests in new format. `#310 <https://github.com/lvgig/tubular/issues/310>`_
 
 
 1.3.1 (2024-07-18)

--- a/tests/dates/test_BaseDatetimeTransformer.py
+++ b/tests/dates/test_BaseDatetimeTransformer.py
@@ -46,8 +46,7 @@ class DatetimeMixinTransformTests:
             df[col] = bad_value
 
             x = uninitialized_transformers[self.transformer_name](
-                columns=columns,
-                new_column_name="c",
+                **args,
             )
 
             msg = rf"{col} type should be in \['datetime64'\] but got {bad_type}"

--- a/tests/dates/test_BaseGenericDateTransformer.py
+++ b/tests/dates/test_BaseGenericDateTransformer.py
@@ -103,8 +103,7 @@ class GenericDatesMixinTransformTests:
             df[col] = bad_value
 
             x = uninitialized_transformers[self.transformer_name](
-                columns=columns,
-                new_column_name="c",
+                **args,
             )
 
             msg = (
@@ -129,12 +128,14 @@ class GenericDatesMixinTransformTests:
         columns,
         datetime_col,
         uninitialized_transformers,
+        minimal_attribute_dict,
     ):
         "Test that transform raises an error if one column is a date and one is datetime"
+        args = minimal_attribute_dict[self.transformer_name].copy()
+        args["columns"] = columns
 
         x = uninitialized_transformers[self.transformer_name](
-            columns=columns,
-            new_column_name="c",
+            **args,
         )
 
         df = create_date_diff_different_dtypes()

--- a/tests/dates/test_DatetimeSinusoidCalculator.py
+++ b/tests/dates/test_DatetimeSinusoidCalculator.py
@@ -9,7 +9,10 @@ from tests.base_tests import (
     ColumnStrListInitTests,
     DropOriginalInitMixinTests,
     GenericFitTests,
+    GenericTransformTests,
+    OtherBaseBehaviourTests,
 )
+from tests.dates.test_BaseDatetimeTransformer import DatetimeMixinTransformTests
 from tubular.dates import DatetimeSinusoidCalculator
 
 
@@ -225,7 +228,13 @@ class TestFit(GenericFitTests):
         cls.transformer_name = "DatetimeSinusoidCalculator"
 
 
-class TestDatetimeSinusoidCalculatorTransform:
+class TestTransform(GenericTransformTests, DatetimeMixinTransformTests):
+    """Tests for BaseTwoColumnDateTransformer.transform."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "DatetimeSinusoidCalculator"
+
     @pytest.mark.parametrize(
         ("bad_column", "bad_type"),
         [
@@ -395,3 +404,15 @@ class TestDatetimeSinusoidCalculatorTransform:
             expected=expected,
             msg_tag="DatetimeSinusoidCalculator transformer does not produce the expected output",
         )
+
+
+class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
+    """
+    Class to run tests for BaseTransformerBehaviour outside the three standard methods.
+
+    May need to overwite specific tests in this class if the tested transformer modifies this behaviour.
+    """
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "DatetimeSinusoidCalculator"

--- a/tests/dates/test_DatetimeSinusoidCalculator.py
+++ b/tests/dates/test_DatetimeSinusoidCalculator.py
@@ -236,32 +236,6 @@ class TestTransform(GenericTransformTests, DatetimeMixinTransformTests):
         cls.transformer_name = "DatetimeSinusoidCalculator"
 
     @pytest.mark.parametrize(
-        ("bad_column", "bad_type"),
-        [
-            ["numeric_col", "int64"],
-            ["string_col", "object"],
-            ["bool_col", "bool"],
-            ["empty_col", "object"],
-            ["date_col", "date"],
-        ],
-    )
-    def test_input_data_check_column_errors(self, bad_column, bad_type):
-        """Check that errors are raised on a variety of different non datatypes"""
-        x = DatetimeSinusoidCalculator(
-            bad_column,
-            "cos",
-            "month",
-            12,
-        )
-
-        df = d.create_date_diff_incorrect_dtypes()
-
-        msg = rf"{x.classname()}: {bad_column} type should be in \['datetime64'\] but got {bad_type}"
-
-        with pytest.raises(TypeError, match=msg):
-            x.transform(df)
-
-    @pytest.mark.parametrize(
         "transformer",
         [
             DatetimeSinusoidCalculator(

--- a/tests/dates/test_DatetimeSinusoidCalculator.py
+++ b/tests/dates/test_DatetimeSinusoidCalculator.py
@@ -5,6 +5,10 @@ import pytest
 import test_aide as ta
 
 import tests.test_data as d
+from tests.base_tests import (
+    ColumnStrListInitTests,
+    DropOriginalInitMixinTests,
+)
 from tubular.dates import DatetimeSinusoidCalculator
 
 
@@ -13,8 +17,15 @@ def example_transformer():
     return DatetimeSinusoidCalculator("a", "cos", "hour", 24)
 
 
-class TestDatetimeSinusoidCalculatorInit:
-    """Tests for DateDifferenceTransformer.init()."""
+class TestInit(
+    ColumnStrListInitTests,
+    DropOriginalInitMixinTests,
+):
+    """Tests for DatetimeSinusoidCalculator.init()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "DatetimeSinusoidCalculator"
 
     @pytest.mark.parametrize("incorrect_type_method", [2, 2.0, True, {"a": 4}])
     def test_method_type_error(self, incorrect_type_method):
@@ -203,18 +214,6 @@ class TestDatetimeSinusoidCalculatorInit:
                 units,
                 24,
             )
-
-    def test_attributes(self, example_transformer):
-        """Test that the value passed for new_column_name and units are saved in attributes of the same name."""
-        ta.classes.test_object_attributes(
-            obj=example_transformer,
-            expected_attributes={
-                "columns": ["a"],
-                "units": "hour",
-                "period": 24,
-            },
-            msg="Attributes for DateDifferenceTransformer set in init",
-        )
 
 
 class TestDatetimeSinusoidCalculatorTransform:

--- a/tests/dates/test_DatetimeSinusoidCalculator.py
+++ b/tests/dates/test_DatetimeSinusoidCalculator.py
@@ -8,6 +8,7 @@ import tests.test_data as d
 from tests.base_tests import (
     ColumnStrListInitTests,
     DropOriginalInitMixinTests,
+    GenericFitTests,
 )
 from tubular.dates import DatetimeSinusoidCalculator
 
@@ -214,6 +215,14 @@ class TestInit(
                 units,
                 24,
             )
+
+
+class TestFit(GenericFitTests):
+    """Generic tests for transformer.fit()"""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "DatetimeSinusoidCalculator"
 
 
 class TestDatetimeSinusoidCalculatorTransform:

--- a/tubular/dates.py
+++ b/tubular/dates.py
@@ -1164,12 +1164,14 @@ class DatetimeSinusoidCalculator(BaseDatetimeTransformer):
         method: str | list[str],
         units: str | dict,
         period: float | dict = 2 * np.pi,
+        verbose: bool = False,
         drop_original: bool = False,
     ) -> None:
         super().__init__(
             columns=columns,
             drop_original=drop_original,
             new_column_name="dummy",
+            verbose=verbose,
         )
 
         if not isinstance(method, str) and not isinstance(method, list):


### PR DESCRIPTION
updates tests for DattimeSinusoidCalculator to new regime

also fixed a couple of tests in test_BaseDatetimeTransformer and test_BaseGenericDateTransformer to make them compatible with other classes as they had specific initialisation arguments in the tests.