### PR TITLE
:bug: fixed bug with get_params method when capping_values=None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,6 +37,7 @@ Changed
 - As part of above, edited dates file transformers to use BaseDropOriginalMixin in transform
 - Refactored DateDiffLeapYearTransformer tests in new format. As part of this had to remove the autodefined new_column_name, as this conflicts with the generic testing. Suggest we look to turn back on in future. `#295 https://github.com/lvgig/tubular/issues/295`
 - Edited base testing setup for dates file, created new BaseDatetimeTransformer class
+- fixed a bug in CappingTransformer which was preventing use of .get_params method `#311 <https://github.com/lvgig/tubular/issues/311>`_
 
 
 1.3.1 (2024-07-18)

--- a/tests/capping/test_CappingTransformer.py
+++ b/tests/capping/test_CappingTransformer.py
@@ -126,3 +126,20 @@ class TestOtherBaseBehaviour(OtherBaseBehaviourTests):
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "CappingTransformer"
+
+    def test_get_params_call_with_capping_values_none(
+        self,
+        uninitialized_transformers,
+        minimal_attribute_dict,
+    ):
+        """Test get_params method when capping_values is None."""
+        args = minimal_attribute_dict[self.transformer_name]
+        args["capping_values"] = None
+        args["quantiles"] = {"a": [0.1, 0.9]}
+        transformer = uninitialized_transformers[self.transformer_name](**args)
+
+        # Ensure no AttributeError is raised when calling get_params method
+        try:
+            transformer.get_params()
+        except AttributeError as e:
+            pytest.fail(f"AttributeError was raised: {e}")

--- a/tubular/capping.py
+++ b/tubular/capping.py
@@ -80,8 +80,6 @@ class BaseCappingTransformer(BaseTransformer, WeightColumnMixin):
         if capping_values is not None:
             self.check_capping_values_dict(capping_values, "capping_values")
 
-            self.capping_values = capping_values
-
             super().__init__(columns=list(capping_values.keys()), **kwargs)
 
         if quantiles is not None:
@@ -98,6 +96,7 @@ class BaseCappingTransformer(BaseTransformer, WeightColumnMixin):
             super().__init__(columns=list(quantiles.keys()), **kwargs)
 
         self.quantiles = quantiles
+        self.capping_values = capping_values
         WeightColumnMixin.check_and_set_weight(self, weights_column)
 
     def check_capping_values_dict(


### PR DESCRIPTION
Fixes issue raised in #292 

Moved setting of self.capping_values out of conditional block so it still happens when capping_values= None.

The lack of a capping_values attribute was causing issues with the get_params method inherited from sklearn.

Added a test for just this transformer.  Arguably should add for rest of package too via base_tests.OtherBaseBehaviour but this would be more involved as it requires iterating through all optional attributes set to None.  I suspect this would require a configuration somewhere as there are probably quite a few cases where args cannot be optional at the same time.