### PR TITLE
272 bring cut transformer in line with new test set up

### DIFF
--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -1,5 +1,3 @@
-import re
-
 import pandas as pd
 import pytest
 import test_aide as ta
@@ -18,47 +16,6 @@ class TestInit(BaseNumericTransformerInitTests):
     @classmethod
     def setup_class(cls):
         cls.transformer_name = "CutTransformer"
-
-    def test_column_type_error(self):
-        """Test that an exception is raised if column is not a str."""
-        with pytest.raises(
-            TypeError,
-            match=re.escape(
-                "CutTransformer: column arg (name of column) should be a single str giving the column to discretise",
-            ),
-        ):
-            CutTransformer(
-                column=["a"],
-                new_column_name="a",
-            )
-
-    def test_new_column_name_type_error(self):
-        """Test that an exception is raised if new_column_name is not a str."""
-        with pytest.raises(
-            TypeError,
-            match="CutTransformer: new_column_name must be a str",
-        ):
-            CutTransformer(column="b", new_column_name=1)
-
-    def test_cut_kwargs_type_error(self):
-        """Test that an exception is raised if cut_kwargs is not a dict."""
-        with pytest.raises(
-            TypeError,
-            match=r"""cut_kwargs should be a dict but got type \<class 'int'\>""",
-        ):
-            CutTransformer(column="b", new_column_name="a", cut_kwargs=1)
-
-    def test_cut_kwargs_key_type_error(self):
-        """Test that an exception is raised if cut_kwargs has keys which are not str."""
-        with pytest.raises(
-            TypeError,
-            match=r"""CutTransformer: unexpected type \(\<class 'int'\>\) for cut_kwargs key in position 1, must be str""",
-        ):
-            CutTransformer(
-                new_column_name="a",
-                column="b",
-                cut_kwargs={"a": 1, 2: "b"},
-            )
 
 
 class TestTransform(BaseNumericTransformerTransformTests):

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -1,34 +1,15 @@
 import re
 
-import pandas
 import pandas as pd
 import pytest
 import test_aide as ta
 
 import tests.test_data as d
-import tubular
 from tubular.numeric import CutTransformer
 
 
 class TestInit:
     """Tests for CutTransformer.init()."""
-
-    def test_super_init_called(self, mocker):
-        """Test that init calls BaseTransformer.init."""
-        expected_call_args = {
-            0: {
-                "args": (),
-                "kwargs": {"columns": ["a"], "verbose": False},
-            },
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "__init__",
-            expected_call_args,
-        ):
-            CutTransformer(column="a", new_column_name="b", verbose=False)
 
     def test_column_type_error(self):
         """Test that an exception is raised if column is not a str."""
@@ -71,25 +52,6 @@ class TestInit:
                 cut_kwargs={"a": 1, 2: "b"},
             )
 
-    def test_inputs_set_to_attribute(self):
-        """Test that the values passed in init are set to attributes."""
-        x = CutTransformer(
-            column="b",
-            new_column_name="a",
-            cut_kwargs={"a": 1, "b": 2},
-        )
-
-        ta.classes.test_object_attributes(
-            obj=x,
-            expected_attributes={
-                "column": "b",
-                "columns": ["b"],
-                "new_column_name": "a",
-                "cut_kwargs": {"a": 1, "b": 2},
-            },
-            msg="Attributes for CutTransformer set in init",
-        )
-
 
 class TestTransform:
     """Tests for CutTransformer.transform()."""
@@ -105,49 +67,6 @@ class TestTransform:
         )
 
         return df
-
-    def test_super_transform_call(self, mocker):
-        """Test the call to BaseTransformer.transform is as expected."""
-        df = d.create_df_9()
-
-        x = CutTransformer(column="a", new_column_name="Y", cut_kwargs={"bins": 3})
-
-        expected_call_args = {0: {"args": (d.create_df_9(),), "kwargs": {}}}
-
-        with ta.functions.assert_function_call(
-            mocker,
-            tubular.base.BaseTransformer,
-            "transform",
-            expected_call_args,
-            return_value=d.create_df_9(),
-        ):
-            x.transform(df)
-
-    def test_pd_cut_call(self, mocker):
-        """Test the call to pd.cut is as expected."""
-        df = d.create_df_9()
-
-        x = CutTransformer(
-            column="a",
-            new_column_name="a_cut",
-            cut_kwargs={"bins": 3, "right": False, "precision": 2},
-        )
-
-        expected_call_args = {
-            0: {
-                "args": (d.create_df_9()["a"].to_numpy(),),
-                "kwargs": {"bins": 3, "right": False, "precision": 2},
-            },
-        }
-
-        with ta.functions.assert_function_call(
-            mocker,
-            pandas,
-            "cut",
-            expected_call_args,
-            return_value=[1, 2, 3, 4, 5, 6],
-        ):
-            x.transform(df)
 
     def test_output_from_cut_assigned_to_column(self, mocker):
         """Test that the output from pd.cut is assigned to column with name new_column_name."""
@@ -187,15 +106,3 @@ class TestTransform:
             actual=df_transformed,
             msg="CutTransformer.transform output",
         )
-
-    def test_non_numeric_column_error(self):
-        """Test that an exception is raised if the column to discretise is not numeric."""
-        df = d.create_df_8()
-
-        x = CutTransformer(column="b", new_column_name="d")
-
-        with pytest.raises(
-            TypeError,
-            match="CutTransformer: b should be a numeric dtype but got object",
-        ):
-            x.transform(df)

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -5,11 +5,19 @@ import pytest
 import test_aide as ta
 
 import tests.test_data as d
+from tests.numeric.test_BaseNumericTransformer import (
+    BaseNumericTransformerInitTests,
+    BaseNumericTransformerTransformTests,
+)
 from tubular.numeric import CutTransformer
 
 
-class TestInit:
+class TestInit(BaseNumericTransformerInitTests):
     """Tests for CutTransformer.init()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "CutTransformer"
 
     def test_column_type_error(self):
         """Test that an exception is raised if column is not a str."""
@@ -53,8 +61,12 @@ class TestInit:
             )
 
 
-class TestTransform:
+class TestTransform(BaseNumericTransformerTransformTests):
     """Tests for CutTransformer.transform()."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.transformer_name = "CutTransformer"
 
     def expected_df_1():
         """Expected output for test_expected_output."""

--- a/tests/numeric/test_CutTransformer.py
+++ b/tests/numeric/test_CutTransformer.py
@@ -17,6 +17,34 @@ class TestInit(BaseNumericTransformerInitTests):
     def setup_class(cls):
         cls.transformer_name = "CutTransformer"
 
+    def test_new_column_name_type_error(self):
+        """Test that an exception is raised if new_column_name is not a str."""
+        with pytest.raises(
+            TypeError,
+            match="CutTransformer: new_column_name must be a str",
+        ):
+            CutTransformer(column="b", new_column_name=1)
+
+    def test_cut_kwargs_type_error(self):
+        """Test that an exception is raised if cut_kwargs is not a dict."""
+        with pytest.raises(
+            TypeError,
+            match=r"""cut_kwargs should be a dict but got type \<class 'int'\>""",
+        ):
+            CutTransformer(column="b", new_column_name="a", cut_kwargs=1)
+
+    def test_cut_kwargs_key_type_error(self):
+        """Test that an exception is raised if cut_kwargs has keys which are not str."""
+        with pytest.raises(
+            TypeError,
+            match=r"""CutTransformer: unexpected type \(\<class 'int'\>\) for cut_kwargs key in position 1, must be str""",
+        ):
+            CutTransformer(
+                new_column_name="a",
+                column="b",
+                cut_kwargs={"a": 1, 2: "b"},
+            )
+
 
 class TestTransform(BaseNumericTransformerTransformTests):
     """Tests for CutTransformer.transform()."""

--- a/tubular/numeric.py
+++ b/tubular/numeric.py
@@ -238,7 +238,7 @@ class LogTransformer(BaseNumericTransformer, DropOriginalMixin):
         return X
 
 
-class CutTransformer(BaseTransformer):
+class CutTransformer(BaseNumericTransformer):
     """Class to bin a column into discrete intervals.
 
     Class simply uses the [pd.cut](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.cut.html)
@@ -306,10 +306,6 @@ class CutTransformer(BaseTransformer):
 
         """
         X = super().transform(X)
-
-        if not pd.api.types.is_numeric_dtype(X[self.columns[0]]):
-            msg = f"{self.classname()}: {self.columns[0]} should be a numeric dtype but got {X[self.columns[0]].dtype}"
-            raise TypeError(msg)
 
         X[self.new_column_name] = pd.cut(
             X[self.columns[0]].to_numpy(),


### PR DESCRIPTION
Adjusted TestInit, TestTransform classes to inherit from base classes & added transformer name class. 

I did not identify any extra tests to perform.

I was able to identify several tests to remove that either tested implementation rather than outputs, and those that were inherited from base classes e.g. non-numeric test.

All tests now pass.

Removed numeric check from transformer itself and updated classes to inherit from base classes.