### PR TITLE
Update CHANGELOG 1.4.0 release date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Subsections for each version can be one of the following;
 
 Each individual change should have a link to the pull request after the description of the change.
 
-1.4.0 (unreleased)
+1.4.0 (2024-10-15)
 ------------------
 
 Changed


### PR DESCRIPTION
corrects forgotten update to release date in changelog on 1.4.0 release