### PR TITLE
Update upload_artifact GHA v3-> v4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload coverage pytest html test results to github
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-html-pytest-results
           path: htmlcov

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
+          name: test-results-${{ matrix.python-version }}
           python-version: ${{ matrix.python-version }}
           
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          name: test-results-${{ matrix.python-version }}
           python-version: ${{ matrix.python-version }}
           
       - name: Install dependencies
@@ -45,7 +44,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-html-pytest-results
+          name: coverage-html-pytest-results-${{ matrix.python-version }}
           path: htmlcov
 
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
+        name: test-results-${{ github.run_id }}-${{ github.run_number }}
         python-version: ">=3.9"
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
-        name: test-results-${{ github.run_id }}-${{ github.run_number }}
         python-version: ">=3.9"
     - name: Install dependencies
       run: |


### PR DESCRIPTION
upload artefact v3 will be deprecated 5th December so our pipelines will all fail without updating this.

-  updates to v4
-  adds in a unique naming for uploaded artefacts as this seems to be a requirement for v4 (otherwise we are uploading the same name for each version of python we iterate through and the python versions)